### PR TITLE
feat: browser pool with lazy creation, idle eviction, burst overflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm run build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        language: system
+        entry: npx eslint --fix
+        types: [ts]
+        files: ^src/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+MCP server that fetches web page content using Playwright headless browser. Exposes three tools (`fetch_url`, `fetch_urls`, `browser_install`) over MCP protocol via stdio or HTTP transport.
+
+## Commands
+
+```bash
+npm install                    # Install dependencies
+npm run install-browser        # Install Playwright Chromium
+npm run build                  # Clean build (rm -rf build && tsc)
+npm run watch                  # TypeScript watch mode
+npm run inspector              # Build + launch MCP Inspector with --debug
+
+# Run locally
+node build/index.js                                          # stdio mode
+node build/index.js --transport=http --host=0.0.0.0 --port=3000 --log  # HTTP mode
+node build/index.js --debug                                  # visible browser window
+```
+
+No test suite or linter is configured.
+
+## Architecture
+
+### Transport Layer (`src/transports/`)
+
+Two transport modes selected via `--transport=` CLI arg (parsed in `src/config/args.ts`):
+
+- **stdio** (default): Single `Server` instance, direct stdin/stdout. `StdioTransportProvider` receives the server directly.
+- **http**: Express server with per-session MCP server instances. `HttpTransportProvider` receives a `ServerFactory` (not a server instance) and calls it for each new session. Exposes:
+  - `POST /mcp` — Streamable HTTP (modern MCP). Session tracked via `mcp-session-id` header.
+  - `GET /sse` + `POST /messages` — Legacy SSE transport.
+
+The `TransportProvider` interface (`src/transports/types.ts`) accepts `Server | ServerFactory` — this dual signature is the key abstraction enabling per-session isolation in HTTP mode while keeping stdio simple.
+
+### Tool Registration (`src/tools/`)
+
+Tools are registered in `src/tools/index.ts` as a flat `tools` array (definitions) and `toolHandlers` map (name → async function). `server.ts` wires these to MCP's `ListToolsRequestSchema` and `CallToolRequestSchema`.
+
+Each tool file exports both the schema object and the handler function. Adding a new tool: create the file, export both, register in `src/tools/index.ts`.
+
+### Content Pipeline (`src/services/`)
+
+`fetchUrl` and `fetchUrls` both follow the same flow:
+
+1. **`BrowserService`** — Launches Chromium with anti-detection (random UA, viewport, stealth init scripts). Creates browser → context → page. Handles cleanup. Debug mode (`--debug` or per-request `debug: true`) keeps browser visible and skips cleanup.
+2. **`WebContentProcessor`** — Navigates page, handles timeouts gracefully (attempts content extraction even after timeout), optional `waitForNavigation` for anti-bot sites, then extracts content:
+   - Raw HTML from Playwright page
+   - Optional Readability extraction (JSDOM + `@mozilla/readability`)
+   - Optional HTML→Markdown conversion (Turndown + GFM plugin)
+   - Optional truncation via `maxLength`
+
+`fetch_urls` shares a single browser instance across all URLs but creates parallel pages via `Promise.all`.
+
+### Logging
+
+`src/utils/logger.ts` — Only active when `--log` CLI flag is present. All output goes to `stderr` (not stdout, which would corrupt stdio MCP transport).
+
+### URL Security
+
+`src/utils/urlValidator.ts` — Restricts URLs to `http:` and `https:` protocols only. Throws `URLSecurityError` for anything else.
+
+## Deployment
+
+Docker image: `ghcr.io/jae-jae/fetcher-mcp:latest`. The Dockerfile bakes in `--transport=http --host=0.0.0.0 --port=3000` as the default CMD. Don't pass CLI args via K8s `args` field — the image has a baked-in entrypoint.
+
+## Key Types
+
+- `FetchOptions` / `FetchResult` — in `src/types/index.ts`
+- `TransportConfig` / `TransportProvider` / `ServerFactory` — in `src/transports/types.ts`

--- a/docs/plans/2026-03-01-quality-hardening-design.md
+++ b/docs/plans/2026-03-01-quality-hardening-design.md
@@ -1,0 +1,68 @@
+# Quality Hardening Design
+
+## Problem
+
+Adopted MCP server with zero safety nets: no tests, no linter, `any` types everywhere, resource leaks in production, unvalidated tool inputs. Two goals: runtime reliability and developer confidence.
+
+## Approach: Zod First + Resource Leak Fixes + Tooling
+
+Prioritized by bang-for-buck. Zod at the input boundary is the highest-leverage single change, then fix actual bugs, then add mechanical safety nets.
+
+## Section 1: Zod Input Validation
+
+Replace manual arg parsing in tool handlers with Zod schemas.
+
+**Current pattern** (duplicated in fetchUrl and fetchUrls):
+```ts
+const options: FetchOptions = {
+  timeout: Number(args?.timeout) || 30000,
+  waitUntil: String(args?.waitUntil || "load") as "load" | ...,
+  extractContent: args?.extractContent !== false,
+};
+```
+
+**New pattern**: Single `FetchOptionsSchema` in `src/types/index.ts` using `z.object()` with defaults. `FetchOptions` type inferred via `z.infer<>`. Tool handlers call `FetchOptionsSchema.parse(args)` — one line replaces ~10 lines of manual coercion per handler.
+
+URL validation stays separate (has side effects). Each tool gets a small wrapper schema for its required field (`url: z.string().url()` / `urls: z.array(z.string().url())`).
+
+**Files changed:**
+- `src/types/index.ts` — schema replaces interface
+- `src/tools/fetchUrl.ts` — delete manual parsing, use schema
+- `src/tools/fetchUrls.ts` — same
+- `src/tools/browserInstall.ts` — small schema for withDeps/force
+- `package.json` — add zod
+
+## Section 2: Resource Leak Fixes
+
+### fetchUrls partial failure leak
+`Promise.all` creates N pages in parallel. If one fails after others succeed, pages that haven't entered their try/finally leak. Fix: use `Promise.allSettled`, return error results for failed URLs.
+
+### BrowserContext never closed
+`createContext()` creates a BrowserContext but `cleanup()` only closes page and browser. Fix: close context explicitly in tool handler finally blocks.
+
+### StdioTransportProvider type mismatch
+Uncommitted changes made `TransportProvider.connect()` accept `Server | ServerFactory`, but stdio still only accepts `Server`. Fix: accept the union, resolve it (call factory if function, use directly if not).
+
+**Files changed:**
+- `src/tools/fetchUrls.ts` — Promise.allSettled, error results
+- `src/tools/fetchUrl.ts` — close context in finally
+- `src/transports/stdio.ts` — accept Server | ServerFactory
+
+## Section 3: ESLint + TypeScript Strictness
+
+Add ESLint with `@typescript-eslint`, minimal config:
+- `no-explicit-any`: warn (ratchet to error after cleanup)
+- `no-unused-vars`: error
+- `noUncheckedIndexedAccess: true` in tsconfig
+
+**`any` kill list:**
+- `src/tools/fetchUrl.ts:79` — `args: any` → Zod-typed
+- `src/tools/fetchUrls.ts:81` — same
+- `src/tools/browserInstall.ts:40` — same
+- `src/transports/http.ts:22` — `server: any` → `http.Server`
+- `src/services/webContentProcessor.ts:18` — `page: any` → `Page`
+- `src/server.ts:46` — handler args typed via tool signature
+
+**New scripts:**
+- `npm run lint` — `eslint src/`
+- `npm run check` — `tsc --noEmit && eslint src/`

--- a/docs/plans/2026-03-01-quality-hardening.md
+++ b/docs/plans/2026-03-01-quality-hardening.md
@@ -1,0 +1,549 @@
+# Quality Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Harden fetcher-mcp with Zod input validation, resource leak fixes, and ESLint/strict TypeScript.
+
+**Architecture:** Three-phase approach — Zod at tool input boundaries first (highest leverage), then fix resource leaks in browser lifecycle, then add mechanical safety nets (ESLint + strict tsconfig). Each phase commits independently.
+
+**Tech Stack:** zod, eslint, @typescript-eslint/eslint-plugin, @typescript-eslint/parser, typescript (strict)
+
+---
+
+### Task 1: Install zod dependency
+
+**Files:**
+- Modify: `package.json`
+
+**Step 1: Install zod**
+
+Run: `npm install zod`
+
+**Step 2: Verify installation**
+
+Run: `npm ls zod`
+Expected: `zod@3.x.x`
+
+**Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add zod dependency"
+```
+
+---
+
+### Task 2: Replace FetchOptions interface with Zod schema
+
+**Files:**
+- Modify: `src/types/index.ts`
+
+**Step 1: Replace the FetchOptions interface and add schemas**
+
+Replace the entire file with:
+
+```ts
+import { z } from "zod";
+
+export const FetchOptionsSchema = z.object({
+  timeout: z.number().positive().default(30000),
+  waitUntil: z.enum(["load", "domcontentloaded", "networkidle", "commit"]).default("load"),
+  extractContent: z.boolean().default(true),
+  maxLength: z.number().nonnegative().default(0),
+  returnHtml: z.boolean().default(false),
+  waitForNavigation: z.boolean().default(false),
+  navigationTimeout: z.number().positive().default(10000),
+  disableMedia: z.boolean().default(true),
+  debug: z.boolean().optional(),
+});
+
+export type FetchOptions = z.infer<typeof FetchOptionsSchema>;
+
+export const FetchUrlArgsSchema = z.object({
+  url: z.string().min(1, "URL parameter is required"),
+}).merge(FetchOptionsSchema.partial());
+
+export const FetchUrlsArgsSchema = z.object({
+  urls: z.array(z.string().min(1)).min(1, "URLs array cannot be empty"),
+}).merge(FetchOptionsSchema.partial());
+
+export const BrowserInstallArgsSchema = z.object({
+  withDeps: z.boolean().default(false),
+  force: z.boolean().default(false),
+});
+
+export interface FetchResult {
+  success: boolean;
+  content: string;
+  error?: string;
+  index?: number;
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: Errors in fetchUrl.ts/fetchUrls.ts (expected — we haven't updated them yet). No errors in types/index.ts itself.
+
+**Step 3: Commit**
+
+```bash
+git add src/types/index.ts
+git commit -m "refactor: replace FetchOptions interface with Zod schemas"
+```
+
+---
+
+### Task 3: Update fetchUrl to use Zod schema
+
+**Files:**
+- Modify: `src/tools/fetchUrl.ts:1-6` (imports)
+- Modify: `src/tools/fetchUrl.ts:79-103` (handler signature + manual parsing)
+- Modify: `src/tools/fetchUrl.ts:117-140` (finally block — add context cleanup)
+
+**Step 1: Update the handler**
+
+Replace import line 4:
+```ts
+import { FetchOptions } from "../types/index.js";
+```
+with:
+```ts
+import { FetchUrlArgsSchema, FetchOptionsSchema } from "../types/index.js";
+```
+
+Replace the handler function (lines 79-103) with:
+
+```ts
+export async function fetchUrl(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlArgsSchema.parse(args);
+  const url = parsed.url;
+
+  // Validate URL protocol for security (only allow HTTP and HTTPS)
+  validateUrlProtocol(url);
+
+  const options = FetchOptionsSchema.parse(parsed);
+```
+
+Replace the finally block (lines 133-140) with:
+
+```ts
+  } finally {
+    // Clean up resources (context is closed implicitly by browser.close())
+    await browserService.cleanup(browser, page);
+
+    if (browserService.isInDebugMode()) {
+      logger.debug(`Browser and page kept open for debugging. URL: ${url}`);
+    }
+  }
+```
+
+Also remove unused `Browser, Page` import if the variables are now typed via inference. Actually keep them — they're used for the `let browser: Browser | null = null` declarations.
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: Still errors in fetchUrls.ts (not updated yet). No errors in fetchUrl.ts.
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/fetchUrl.ts
+git commit -m "refactor: use Zod schema for fetchUrl input validation"
+```
+
+---
+
+### Task 4: Update fetchUrls to use Zod schema + Promise.allSettled
+
+**Files:**
+- Modify: `src/tools/fetchUrls.ts:1-6` (imports)
+- Modify: `src/tools/fetchUrls.ts:81-165` (handler — Zod + allSettled + context cleanup)
+
+**Step 1: Update the handler**
+
+Replace import line 4:
+```ts
+import { FetchOptions, FetchResult } from "../types/index.js";
+```
+with:
+```ts
+import { FetchUrlsArgsSchema, FetchOptionsSchema, FetchResult } from "../types/index.js";
+```
+
+Replace the handler function (lines 81-165) with:
+
+```ts
+export async function fetchUrls(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlsArgsSchema.parse(args);
+  const urls = parsed.urls;
+
+  // Validate all URLs protocols for security (only allow HTTP and HTTPS)
+  validateUrlsProtocol(urls);
+
+  const options = FetchOptionsSchema.parse(parsed);
+
+  // Create browser service
+  const browserService = new BrowserService(options);
+
+  if (browserService.isInDebugMode()) {
+    logger.debug(`Debug mode enabled for URLs: ${urls.join(", ")}`);
+  }
+
+  let browser: Browser | null = null;
+  try {
+    // Create a stealth browser with anti-detection measures
+    browser = await browserService.createBrowser();
+
+    // Create a stealth browser context
+    const { context, viewport } = await browserService.createContext(browser);
+
+    const processor = new WebContentProcessor(options, "[FetchURLs]");
+
+    const settled = await Promise.allSettled(
+      urls.map(async (url, index) => {
+        const page = await browserService.createPage(context, viewport);
+
+        try {
+          const result = await processor.processPageContent(page, url);
+          return { index, ...result } as FetchResult;
+        } finally {
+          if (!browserService.isInDebugMode()) {
+            await page
+              .close()
+              .catch((e) => logger.error(`Failed to close page: ${e.message}`));
+          } else {
+            logger.debug(`Page kept open for debugging. URL: ${url}`);
+          }
+        }
+      }),
+    );
+
+    // Convert settled results to FetchResults (handle rejections gracefully)
+    const results: FetchResult[] = settled.map((outcome, i) => {
+      if (outcome.status === "fulfilled") {
+        return outcome.value;
+      }
+      const errorMessage = outcome.reason instanceof Error
+        ? outcome.reason.message
+        : String(outcome.reason);
+      logger.error(`[FetchURLs] Failed to fetch URL ${urls[i]}: ${errorMessage}`);
+      return {
+        success: false,
+        content: `Title: Error\nURL: ${urls[i]}\nContent:\n\n<error>Failed to retrieve web page content: ${errorMessage}</error>`,
+        error: errorMessage,
+        index: i,
+      };
+    });
+
+    results.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    const combinedResults = results
+      .map(
+        (result, i) =>
+          `[webpage ${i + 1} begin]\n${result.content}\n[webpage ${i + 1} end]`,
+      )
+      .join("\n\n");
+
+    return {
+      content: [{ type: "text", text: combinedResults }],
+    };
+  } finally {
+    // Clean up browser resources (closes all contexts implicitly)
+    if (!browserService.isInDebugMode()) {
+      if (browser)
+        await browser
+          .close()
+          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
+    } else {
+      logger.debug(`Browser kept open for debugging. URLs: ${urls.join(", ")}`);
+    }
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors in fetchUrls.ts.
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/fetchUrls.ts
+git commit -m "refactor: use Zod schema + Promise.allSettled for fetchUrls"
+```
+
+---
+
+### Task 5: Update browserInstall to use Zod schema
+
+**Files:**
+- Modify: `src/tools/browserInstall.ts:4` (add import)
+- Modify: `src/tools/browserInstall.ts:40-42` (handler signature + parsing)
+
+**Step 1: Update the handler**
+
+Add import after line 4:
+```ts
+import { BrowserInstallArgsSchema } from "../types/index.js";
+```
+
+Replace lines 40-42:
+```ts
+export async function browserInstall(args: any) {
+  const withDeps = args?.withDeps === true;
+  const force = args?.force === true;
+```
+with:
+```ts
+export async function browserInstall(args: Record<string, unknown> = {}) {
+  const { withDeps, force } = BrowserInstallArgsSchema.parse(args);
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/browserInstall.ts
+git commit -m "refactor: use Zod schema for browserInstall input validation"
+```
+
+---
+
+### Task 6: Fix StdioTransportProvider type mismatch
+
+**Files:**
+- Modify: `src/transports/stdio.ts:1-3` (imports)
+- Modify: `src/transports/stdio.ts:17-21` (connect method)
+
+**Step 1: Fix the connect method**
+
+Replace lines 1-3:
+```ts
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { TransportProvider } from "./types.js";
+```
+with:
+```ts
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { TransportProvider, ServerFactory } from "./types.js";
+```
+
+Replace lines 17-21:
+```ts
+  async connect(server: Server): Promise<void> {
+    logger.info("[Transport] Connecting server using Stdio transport");
+    this.transport = new StdioServerTransport();
+    await server.connect(this.transport);
+    logger.info("[Transport] Stdio transport connected");
+  }
+```
+with:
+```ts
+  async connect(serverOrFactory: Server | ServerFactory): Promise<void> {
+    const server = typeof serverOrFactory === "function"
+      ? serverOrFactory()
+      : serverOrFactory;
+    logger.info("[Transport] Connecting server using Stdio transport");
+    this.transport = new StdioServerTransport();
+    await server.connect(this.transport);
+    logger.info("[Transport] Stdio transport connected");
+  }
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/transports/stdio.ts
+git commit -m "fix: StdioTransportProvider accepts Server | ServerFactory"
+```
+
+---
+
+### Task 7: Kill remaining `any` types
+
+**Files:**
+- Modify: `src/transports/http.ts:12-13` (isInitializeRequest param)
+- Modify: `src/transports/http.ts:22` (server field type)
+- Modify: `src/services/webContentProcessor.ts:18,144,164` (page param types)
+- Modify: `src/server.ts:46` (handler args type)
+- Modify: `src/tools/index.ts` (toolHandlers type)
+
+**Step 1: Fix http.ts types**
+
+Add import at top of `src/transports/http.ts`:
+```ts
+import { Server as HttpServer } from "node:http";
+```
+
+Replace line 12-13:
+```ts
+function isInitializeRequest(body: any): boolean {
+  return body?.method === "initialize" && body?.jsonrpc === "2.0";
+```
+with:
+```ts
+function isInitializeRequest(body: Record<string, unknown>): boolean {
+  return body?.method === "initialize" && body?.jsonrpc === "2.0";
+```
+
+Replace line 22:
+```ts
+  private server: any; // HTTP server instance
+```
+with:
+```ts
+  private server: HttpServer | null = null;
+```
+
+This will require updating the `close()` method's null check (line 95) — it already checks `if (this.server)` so that's fine. But the `.close()` callback typing on line 97 needs to handle `Error | undefined`:
+```ts
+        this.server.close((err?: Error) => {
+```
+
+**Step 2: Fix webContentProcessor.ts page types**
+
+Add `Page` to existing playwright imports or add new import in `src/services/webContentProcessor.ts`:
+```ts
+import { Page } from "playwright";
+```
+
+Replace `page: any` with `page: Page` at lines 18, 144, and 164.
+
+**Step 3: Fix server.ts handler args**
+
+In `src/server.ts` line 46, the `request.params.arguments` is already typed by the MCP SDK — no change needed, it's `Record<string, unknown> | undefined`. The handlers now accept `Record<string, unknown>` so this is compatible.
+
+**Step 4: Type the toolHandlers map**
+
+In `src/tools/index.ts`, add a type for the handlers map:
+
+```ts
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[] }>;
+
+export const toolHandlers: Record<string, ToolHandler> = {
+  [fetchUrlTool.name]: fetchUrl,
+  [fetchUrlsTool.name]: fetchUrls,
+  [browserInstallTool.name]: browserInstall
+};
+```
+
+**Step 5: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+**Step 6: Commit**
+
+```bash
+git add src/transports/http.ts src/services/webContentProcessor.ts src/server.ts src/tools/index.ts
+git commit -m "refactor: eliminate any types across codebase"
+```
+
+---
+
+### Task 8: Add ESLint + strict tsconfig
+
+**Files:**
+- Create: `eslint.config.js`
+- Modify: `tsconfig.json`
+- Modify: `package.json` (scripts + devDeps)
+
+**Step 1: Install ESLint devDeps**
+
+Run: `npm install --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser`
+
+**Step 2: Create eslint.config.js**
+
+```js
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+
+export default [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+];
+```
+
+**Step 3: Add noUncheckedIndexedAccess to tsconfig.json**
+
+Add to `compilerOptions`:
+```json
+"noUncheckedIndexedAccess": true
+```
+
+**Step 4: Add scripts to package.json**
+
+```json
+"lint": "eslint src/",
+"check": "tsc --noEmit && eslint src/"
+```
+
+**Step 5: Run lint and fix any issues**
+
+Run: `npm run check`
+Expected: Clean pass (or only `any` warnings from the `@ts-ignore` on turndown-plugin-gfm in webContentProcessor.ts — that one is acceptable because the package has no types).
+
+**Step 6: Handle noUncheckedIndexedAccess fallout**
+
+The `toolHandlers[toolName]` access in `server.ts:40` will now be `ToolHandler | undefined`. The existing `if (!handler)` guard on line 42 already handles this — TypeScript should narrow correctly.
+
+**Step 7: Commit**
+
+```bash
+git add eslint.config.js tsconfig.json package.json package-lock.json
+git commit -m "chore: add ESLint + strict TypeScript settings"
+```
+
+---
+
+### Task 9: Build and verify
+
+**Files:** None (verification only)
+
+**Step 1: Full build**
+
+Run: `npm run build`
+Expected: Clean build, `build/` directory populated.
+
+**Step 2: Full check**
+
+Run: `npm run check`
+Expected: No errors, only acceptable warnings.
+
+**Step 3: Smoke test stdio mode**
+
+Run: `echo '{"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{}},"id":1}' | node build/index.js`
+Expected: JSON-RPC response with server capabilities.
+
+**Step 4: Smoke test HTTP mode**
+
+Run in background: `node build/index.js --transport=http --port=3001 --log &`
+Then: `curl -s -X POST http://localhost:3001/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{}},"id":1}'`
+Expected: JSON-RPC response with session ID in header.
+Cleanup: kill the background process.

--- a/docs/plans/2026-03-07-browser-pool-design.md
+++ b/docs/plans/2026-03-07-browser-pool-design.md
@@ -1,0 +1,47 @@
+# Browser Pool Design
+
+## Date: 2026-03-07
+
+## Context
+
+The fetcher-mcp server launches and kills a Chromium process per `fetch_url` call (~1-2s cold start). With multiple simultaneous clients in HTTP transport mode, this is wasteful. Need browser pooling.
+
+## Decision
+
+Singleton pool of headless browser instances with acquire/release semantics.
+
+### Configuration (env vars)
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `BROWSER_POOL_SIZE` | 3 | Max pooled browsers |
+| `BROWSER_POOL_WARM` | 1 | Pre-warmed at startup (capped at pool size) |
+| `BROWSER_IDLE_TIMEOUT` | 300 | Seconds before idle eviction |
+
+### Behavior
+
+- **Lazy + warm**: Pre-warm N browsers at startup, create more on demand up to max
+- **Burst overflow**: When pool is exhausted, create temporary browsers beyond max — destroyed on release
+- **Idle eviction**: Browsers idle > timeout are closed, but never drops below warm count
+- **Debug bypass**: `debug: true` requests always get a burst browser with `headless: false`, never pooled
+- **Crash recovery**: Dead browsers (`!browser.isConnected()`) are discarded on acquire, replaced with fresh ones
+- **Context-per-request**: Each request creates an isolated `BrowserContext` on the acquired browser
+
+### Integration
+
+- `src/services/browserPool.ts` — pool implementation
+- `src/services/browserService.ts` — keeps context/page creation, loses `createBrowser()`
+- `src/tools/fetchUrl.ts` / `fetchUrls.ts` — acquire from pool
+- `src/server.ts` — wire pool shutdown into graceful shutdown
+- `src/index.ts` — warm pool after server starts
+
+### BrowserHandle contract
+
+```typescript
+interface BrowserHandle {
+  browser: Browser;
+  release(): Promise<void>;
+}
+```
+
+Callers MUST call `release()` in a `finally` block.

--- a/docs/plans/2026-03-07-browser-pool.md
+++ b/docs/plans/2026-03-07-browser-pool.md
@@ -1,0 +1,579 @@
+# Browser Pool Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a singleton browser pool with lazy creation, idle eviction, warm browsers, and burst overflow to eliminate per-request Chromium cold starts.
+
+**Architecture:** A `BrowserPool` singleton manages headless Chromium instances with acquire/release semantics. Tool handlers acquire a browser, create an isolated `BrowserContext` for the request, then release. Debug requests bypass the pool with temporary visible browsers. Pool integrates with server lifecycle for graceful shutdown.
+
+**Tech Stack:** Playwright (chromium), Node.js timers for idle eviction
+
+---
+
+### Task 1: Create BrowserPool service
+
+**Files:**
+- Create: `src/services/browserPool.ts`
+
+**Step 1: Write the BrowserPool class**
+
+This is the core pool implementation. No test framework exists in this project, so we verify manually via `npm run check`.
+
+```typescript
+import { Browser, chromium } from "playwright";
+import { logger } from "../utils/logger.js";
+
+export interface BrowserHandle {
+  browser: Browser;
+  release(): Promise<void>;
+}
+
+interface PooledBrowser {
+  browser: Browser;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class BrowserPool {
+  private static instance: BrowserPool | null = null;
+
+  private idle: PooledBrowser[] = [];
+  private inUse = 0;
+  private poolSize: number;
+  private warmCount: number;
+  private idleTimeoutMs: number;
+  private shutdownRequested = false;
+
+  private constructor() {
+    this.poolSize = this.envInt("BROWSER_POOL_SIZE", 3);
+    this.warmCount = Math.min(
+      this.envInt("BROWSER_POOL_WARM", 1),
+      this.poolSize,
+    );
+    this.idleTimeoutMs = this.envInt("BROWSER_IDLE_TIMEOUT", 300) * 1000;
+  }
+
+  static getInstance(): BrowserPool {
+    if (!BrowserPool.instance) {
+      BrowserPool.instance = new BrowserPool();
+    }
+    return BrowserPool.instance;
+  }
+
+  /** Pre-warm browsers up to warmCount. Call after server starts. */
+  async warm(): Promise<void> {
+    const toCreate = this.warmCount - this.idle.length;
+    for (let i = 0; i < toCreate; i++) {
+      try {
+        const browser = await this.launchBrowser();
+        this.addToIdle(browser);
+        logger.info(`[BrowserPool] Warmed browser ${i + 1}/${toCreate}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[BrowserPool] Failed to warm browser: ${msg}`);
+      }
+    }
+  }
+
+  /**
+   * Acquire a browser from the pool.
+   * - If debug is true, creates a temporary visible browser (never pooled).
+   * - Otherwise returns a pooled browser, creating or bursting as needed.
+   */
+  async acquire(debug = false): Promise<BrowserHandle> {
+    if (this.shutdownRequested) {
+      throw new Error("BrowserPool is shutting down");
+    }
+
+    // Debug requests always get a temporary visible browser
+    if (debug) {
+      const browser = await this.launchBrowser(false);
+      logger.debug("[BrowserPool] Created burst browser for debug request");
+      return {
+        browser,
+        release: async () => {
+          // Debug browsers stay open — don't close
+          logger.debug("[BrowserPool] Debug browser kept open");
+        },
+      };
+    }
+
+    // Try to get an idle browser
+    while (this.idle.length > 0) {
+      const pooled = this.idle.pop()!;
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+
+      if (pooled.browser.isConnected()) {
+        this.inUse++;
+        logger.debug(
+          `[BrowserPool] Acquired idle browser (idle=${this.idle.length} inUse=${this.inUse})`,
+        );
+        return this.createHandle(pooled.browser, false);
+      }
+      // Dead browser — discard and try next
+      logger.warn("[BrowserPool] Discarded dead browser from pool");
+    }
+
+    // No idle browsers — create a new one
+    const isBurst = this.inUse >= this.poolSize;
+    const browser = await this.launchBrowser();
+    this.inUse++;
+
+    if (isBurst) {
+      logger.info(
+        `[BrowserPool] Created burst browser (inUse=${this.inUse}, poolSize=${this.poolSize})`,
+      );
+    } else {
+      logger.debug(
+        `[BrowserPool] Created new pooled browser (idle=${this.idle.length} inUse=${this.inUse})`,
+      );
+    }
+
+    return this.createHandle(browser, isBurst);
+  }
+
+  /** Graceful shutdown — close all browsers. */
+  async shutdown(): Promise<void> {
+    this.shutdownRequested = true;
+    logger.info("[BrowserPool] Shutting down...");
+
+    // Clear idle timers and close idle browsers
+    for (const pooled of this.idle) {
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+      await this.closeBrowser(pooled.browser);
+    }
+    this.idle = [];
+
+    // In-use browsers will be closed when their handles are released
+    // (release() checks shutdownRequested)
+    logger.info("[BrowserPool] Shutdown complete");
+  }
+
+  /** Reset singleton — for testing only. */
+  static resetInstance(): void {
+    BrowserPool.instance = null;
+  }
+
+  private createHandle(browser: Browser, isBurst: boolean): BrowserHandle {
+    let released = false;
+    return {
+      browser,
+      release: async () => {
+        if (released) return;
+        released = true;
+        this.inUse--;
+
+        if (isBurst || this.shutdownRequested) {
+          await this.closeBrowser(browser);
+          if (isBurst) {
+            logger.debug("[BrowserPool] Destroyed burst browser");
+          }
+          return;
+        }
+
+        if (browser.isConnected()) {
+          this.addToIdle(browser);
+          logger.debug(
+            `[BrowserPool] Released browser to pool (idle=${this.idle.length} inUse=${this.inUse})`,
+          );
+        } else {
+          logger.warn("[BrowserPool] Released browser was dead, discarding");
+        }
+      },
+    };
+  }
+
+  private addToIdle(browser: Browser): void {
+    const pooled: PooledBrowser = { browser, idleTimer: null };
+
+    // Only set idle timer if we're above warm count
+    if (this.idle.length >= this.warmCount) {
+      pooled.idleTimer = setTimeout(() => {
+        const idx = this.idle.indexOf(pooled);
+        if (idx !== -1 && this.idle.length > this.warmCount) {
+          this.idle.splice(idx, 1);
+          this.closeBrowser(pooled.browser);
+          logger.info(
+            `[BrowserPool] Evicted idle browser (idle=${this.idle.length})`,
+          );
+        }
+      }, this.idleTimeoutMs);
+    }
+
+    this.idle.push(pooled);
+  }
+
+  private async launchBrowser(headless = true): Promise<Browser> {
+    return chromium.launch({
+      headless,
+      args: [
+        "--disable-blink-features=AutomationControlled",
+        "--disable-features=IsolateOrigins,site-per-process",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-webgl",
+        "--disable-infobars",
+        "--disable-extensions",
+      ],
+    });
+  }
+
+  private async closeBrowser(browser: Browser): Promise<void> {
+    try {
+      if (browser.isConnected()) await browser.close();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[BrowserPool] Failed to close browser: ${msg}`);
+    }
+  }
+
+  private envInt(name: string, defaultVal: number): number {
+    const val = process.env[name];
+    if (!val) return defaultVal;
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      logger.warn(
+        `[BrowserPool] Invalid ${name}=${val}, using default ${defaultVal}`,
+      );
+      return defaultVal;
+    }
+    return parsed;
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add src/services/browserPool.ts
+git commit -m "feat: add BrowserPool with lazy creation, idle eviction, burst overflow"
+```
+
+---
+
+### Task 2: Refactor BrowserService — remove createBrowser, keep context/page
+
+**Files:**
+- Modify: `src/services/browserService.ts`
+
+**Step 1: Remove `createBrowser()`, `isBrowserNotInstalledError()`, and the `chromium` import**
+
+The pool now owns browser creation. BrowserService keeps context creation, page creation, anti-detection, and media handling. Also remove `cleanup()` — callers will close contexts directly, and the pool handles browser lifecycle.
+
+Remove:
+- Line 1: `chromium` from the import
+- Lines 133-177: `createBrowser()` and `isBrowserNotInstalledError()`
+- Lines 232-250: `cleanup()` method
+
+The `chromium` import becomes unused. The remaining import should be:
+```typescript
+import { Browser, BrowserContext, Page } from "playwright";
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: Errors in fetchUrl.ts and fetchUrls.ts (they still call `createBrowser()` and `cleanup()`). That's expected — we fix those next.
+
+**Step 3: Commit**
+
+```bash
+git add src/services/browserService.ts
+git commit -m "refactor: remove browser lifecycle from BrowserService (pool owns it now)"
+```
+
+---
+
+### Task 3: Refactor fetchUrl to use BrowserPool
+
+**Files:**
+- Modify: `src/tools/fetchUrl.ts`
+
+**Step 1: Replace browser creation with pool acquire/release**
+
+The new flow: acquire handle from pool → create context → create page → process → close context → release handle.
+
+```typescript
+import { Page } from "playwright";
+import { WebContentProcessor } from "../services/webContentProcessor.js";
+import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
+import { FetchUrlArgsSchema, FetchOptionsSchema } from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { validateUrlProtocol } from "../utils/urlValidator.js";
+
+// ... fetchUrlTool definition unchanged ...
+
+export async function fetchUrl(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlArgsSchema.parse(args);
+  const url = parsed.url;
+
+  validateUrlProtocol(url);
+
+  const options = FetchOptionsSchema.parse(parsed);
+  const browserService = new BrowserService(options);
+  const processor = new WebContentProcessor(options, "[FetchURL]");
+
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
+  let page: Page | null = null;
+
+  try {
+    handle = await pool.acquire(browserService.isInDebugMode());
+    const { context, viewport } = await browserService.createContext(handle.browser);
+
+    try {
+      page = await browserService.createPage(context, viewport);
+      const result = await processor.processPageContent(page, url);
+
+      return {
+        content: [{ type: "text", text: result.content }],
+      };
+    } finally {
+      if (!browserService.isInDebugMode()) {
+        await context.close().catch((e) =>
+          logger.error(`[FetchURL] Failed to close context: ${e.message}`)
+        );
+      }
+    }
+  } finally {
+    if (handle) await handle.release();
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: fetchUrl clean, fetchUrls still has errors (next task)
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/fetchUrl.ts
+git commit -m "refactor: fetchUrl uses BrowserPool acquire/release"
+```
+
+---
+
+### Task 4: Refactor fetchUrls to use BrowserPool
+
+**Files:**
+- Modify: `src/tools/fetchUrls.ts`
+
+**Step 1: Replace browser creation with pool acquire/release**
+
+Same pattern as fetchUrl. One acquire for the entire batch (all pages share the same browser). Context-per-page for isolation within the batch.
+
+```typescript
+import pLimit from "p-limit";
+import { WebContentProcessor } from "../services/webContentProcessor.js";
+import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
+import { FetchUrlsArgsSchema, FetchOptionsSchema, FetchResult } from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { validateUrlsProtocol } from "../utils/urlValidator.js";
+
+// ... fetchUrlsTool definition unchanged ...
+
+export async function fetchUrls(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlsArgsSchema.parse(args);
+  const urls = parsed.urls;
+
+  validateUrlsProtocol(urls);
+
+  const options = FetchOptionsSchema.parse(parsed);
+
+  let maxConcurrentPages = parseInt(
+    process.env.MAX_CONCURRENT_PAGES || "5",
+    10
+  );
+  if (isNaN(maxConcurrentPages) || maxConcurrentPages <= 0) {
+    logger.warn(
+      `Invalid MAX_CONCURRENT_PAGES value, using default of 5. Got: ${process.env.MAX_CONCURRENT_PAGES}`
+    );
+    maxConcurrentPages = 5;
+  }
+  const limit = pLimit(maxConcurrentPages);
+
+  const browserService = new BrowserService(options);
+  const processor = new WebContentProcessor(options, "[FetchURLs]");
+
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
+
+  try {
+    handle = await pool.acquire(browserService.isInDebugMode());
+
+    const settled = await Promise.allSettled(
+      urls.map((url, index) =>
+        limit(async () => {
+          const { context, viewport } = await browserService.createContext(handle!.browser);
+          try {
+            const page = await browserService.createPage(context, viewport);
+            try {
+              const result = await processor.processPageContent(page, url);
+              return { index, ...result } as FetchResult;
+            } finally {
+              if (!browserService.isInDebugMode()) {
+                await page.close().catch((e) =>
+                  logger.error(`[FetchURLs] Failed to close page: ${e.message}`)
+                );
+              }
+            }
+          } finally {
+            if (!browserService.isInDebugMode()) {
+              await context.close().catch((e) =>
+                logger.error(`[FetchURLs] Failed to close context: ${e.message}`)
+              );
+            }
+          }
+        })
+      ),
+    );
+
+    const results: FetchResult[] = settled.map((outcome, i) => {
+      if (outcome.status === "fulfilled") {
+        return outcome.value;
+      }
+      const errorMessage = outcome.reason instanceof Error
+        ? outcome.reason.message
+        : String(outcome.reason);
+      logger.error(`[FetchURLs] Failed to fetch URL ${urls[i]}: ${errorMessage}`);
+      return {
+        success: false,
+        content: `Title: Error\nURL: ${urls[i]}\nContent:\n\n<error>Failed to retrieve web page content: ${errorMessage}</error>`,
+        error: errorMessage,
+        index: i,
+      };
+    });
+
+    results.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    const combinedResults = results
+      .map(
+        (result, i) =>
+          `[webpage ${i + 1} begin]\n${result.content}\n[webpage ${i + 1} end]`,
+      )
+      .join("\n\n");
+
+    return {
+      content: [{ type: "text", text: combinedResults }],
+    };
+  } finally {
+    if (handle) await handle.release();
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/fetchUrls.ts
+git commit -m "refactor: fetchUrls uses BrowserPool acquire/release"
+```
+
+---
+
+### Task 5: Wire pool into server lifecycle
+
+**Files:**
+- Modify: `src/server.ts` — add pool shutdown to graceful shutdown
+- Modify: `src/index.ts` — warm pool after server starts
+
+**Step 1: Add pool shutdown to server.ts**
+
+In `setupProcessHandlers`, update `gracefulShutdown` to also shut down the pool:
+
+```typescript
+import { BrowserPool } from "./services/browserPool.js";
+
+// In setupProcessHandlers, change gracefulShutdown to:
+const gracefulShutdown = async () => {
+  logger.info("[Server] Starting graceful shutdown...");
+  await BrowserPool.getInstance().shutdown();
+  return transportProvider.close();
+};
+```
+
+**Step 2: Add pool warming to index.ts**
+
+After `await startServer(transportProvider)`, add:
+
+```typescript
+import { BrowserPool } from "./services/browserPool.js";
+
+// After startServer call:
+await BrowserPool.getInstance().warm();
+```
+
+**Step 3: Verify it compiles and builds**
+
+Run: `npm run check && npm run build`
+Expected: 0 errors, clean build
+
+**Step 4: Commit**
+
+```bash
+git add src/server.ts src/index.ts
+git commit -m "feat: wire BrowserPool into server startup/shutdown lifecycle"
+```
+
+---
+
+### Task 6: Clean up BrowserService
+
+**Files:**
+- Modify: `src/services/browserService.ts`
+
+**Step 1: Remove dead code**
+
+After tasks 2-5, `createBrowser()`, `isBrowserNotInstalledError()`, and `cleanup()` should already be removed. Verify no dead methods remain. Also check that the browser-not-installed error hint still surfaces somewhere useful — it should, since `BrowserPool.launchBrowser()` will throw Playwright's native error which includes install instructions.
+
+**Step 2: Verify full pipeline**
+
+Run: `npm run check && npm run build`
+Expected: 0 errors, clean build
+
+**Step 3: Commit (if any cleanup was needed)**
+
+```bash
+git add src/services/browserService.ts
+git commit -m "refactor: clean up BrowserService after pool integration"
+```
+
+---
+
+### Task 7: Final verification
+
+**Step 1: Full quality check**
+
+Run: `npm run check && npm run build`
+Expected: 0 errors, clean build
+
+**Step 2: Manual smoke test**
+
+```bash
+# Quick test — start server, it should warm 1 browser
+node build/index.js --transport=http --host=127.0.0.1 --port=3000 --log 2>&1 &
+sleep 3
+
+# Check logs show pool warming
+# Kill with Ctrl+C — should show graceful shutdown + pool shutdown
+kill %1
+```
+
+**Step 3: Commit any final fixes, push**
+
+```bash
+git push origin main
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,21 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+
+export default [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetcher-mcp",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetcher-mcp",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -14,6 +14,7 @@
         "@mozilla/readability": "^0.5.0",
         "express": "^4.18.2",
         "jsdom": "^24.0.0",
+        "p-limit": "^7.2.0",
         "playwright": "^1.42.1",
         "turndown": "^7.1.2"
       },
@@ -1508,6 +1509,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.2.0.tgz",
+      "integrity": "sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
@@ -2150,6 +2166,18 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zod": {
       "version": "3.24.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,24 @@
 {
   "name": "fetcher-mcp",
-  "version": "0.3.5",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetcher-mcp",
-      "version": "0.3.5",
+      "version": "0.3.9",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.2",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@mozilla/readability": "^0.5.0",
         "express": "^4.18.2",
         "jsdom": "^24.0.0",
         "p-limit": "^7.2.0",
         "playwright": "^1.42.1",
-        "turndown": "^7.1.2"
+        "turndown": "^7.1.2",
+        "turndown-plugin-gfm": "^1.0.2",
+        "zod": "^4.3.6"
       },
       "bin": {
         "fetcher-mcp": "build/index.js"
@@ -26,6 +28,9 @@
         "@types/jsdom": "^21.1.6",
         "@types/node": "^20.17.24",
         "@types/turndown": "^5.0.4",
+        "@typescript-eslint/eslint-plugin": "^8.56.1",
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^10.0.2",
         "typescript": "^5.3.3"
       }
     },
@@ -152,6 +157,164 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
+      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
+      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
@@ -159,24 +322,43 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
-      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
@@ -193,35 +375,40 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
@@ -234,18 +421,19 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -276,9 +464,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -289,7 +477,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
@@ -299,6 +491,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
@@ -332,15 +560,19 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
@@ -353,9 +585,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -368,31 +600,35 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -402,6 +638,19 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
@@ -448,6 +697,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
@@ -492,6 +755,13 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -561,6 +831,239 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -574,6 +1077,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -581,6 +1107,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/array-flatten": {
@@ -594,6 +1153,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -659,6 +1228,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -807,9 +1389,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -827,6 +1409,13 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -949,6 +1538,231 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.1",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
+      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
+      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1026,10 +1840,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1037,7 +1854,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -1054,6 +1871,73 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
@@ -1087,6 +1971,44 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data": {
       "version": "4.0.2",
@@ -1181,6 +2103,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1230,6 +2165,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -1298,11 +2242,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1311,6 +2284,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -1330,6 +2326,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/jsdom": {
       "version": "24.1.3",
@@ -1369,6 +2374,72 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -1446,10 +2517,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1509,6 +2603,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.2.0.tgz",
@@ -1519,6 +2631,51 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1545,6 +2702,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1559,6 +2726,19 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.0",
@@ -1597,6 +2777,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1664,18 +2854,72 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/requires-port": {
@@ -1701,12 +2945,13 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -1751,6 +2996,19 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -1930,6 +3188,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1966,6 +3241,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/turndown": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
@@ -1973,6 +3261,25 @@
       "license": "MIT",
       "dependencies": {
         "@mixmark-io/domino": "^2.2.0"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-is": {
@@ -2025,6 +3332,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {
@@ -2125,6 +3442,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2180,21 +3507,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mozilla/readability": "^0.5.0",
     "express": "^4.18.2",
     "jsdom": "^24.0.0",
+    "p-limit": "^7.2.0",
     "playwright": "^1.42.1",
     "turndown": "^7.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher-mcp",
-  "version": "0.3.5",
+  "version": "0.3.9",
   "description": "MCP server for fetching web content using Playwright browser",
   "private": false,
   "type": "module",
@@ -16,22 +16,29 @@
     "watch": "tsc --watch",
     "inspector": "npm run build && npx @modelcontextprotocol/inspector build/index.js --debug",
     "install-browser": "npx playwright install chromium",
-    "postinstall": "playwright install chromium"
+    "postinstall": "playwright install chromium",
+    "lint": "eslint src/",
+    "check": "tsc --noEmit && eslint src/"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@mozilla/readability": "^0.5.0",
     "express": "^4.18.2",
     "jsdom": "^24.0.0",
     "p-limit": "^7.2.0",
     "playwright": "^1.42.1",
-    "turndown": "^7.1.2"
+    "turndown": "^7.1.2",
+    "turndown-plugin-gfm": "^1.0.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20.17.24",
     "@types/turndown": "^5.0.4",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
+    "eslint": "^10.0.2",
     "typescript": "^5.3.3"
   },
   "main": "index.js",

--- a/src/config/args.ts
+++ b/src/config/args.ts
@@ -13,7 +13,7 @@ export function parseTransportConfig(): TransportConfig {
   // Parse transport type
   const transportArg = args.find((arg) => arg.startsWith("--transport="));
   if (transportArg) {
-    const transportValue = transportArg.split("=")[1].toLowerCase();
+    const transportValue = transportArg.split("=")[1]?.toLowerCase();
     if (transportValue === "http") {
       config.type = "http";
     }
@@ -24,7 +24,7 @@ export function parseTransportConfig(): TransportConfig {
     // Parse port
     const portArg = args.find((arg) => arg.startsWith("--port="));
     if (portArg) {
-      const portValue = parseInt(portArg.split("=")[1], 10);
+      const portValue = parseInt(portArg.split("=")[1] ?? "", 10);
       if (!isNaN(portValue)) {
         config.port = portValue;
       }
@@ -33,7 +33,7 @@ export function parseTransportConfig(): TransportConfig {
     // Parse host
     const hostArg = args.find((arg) => arg.startsWith("--host="));
     if (hostArg) {
-      config.host = hostArg.split("=")[1];
+      config.host = hostArg.split("=")[1] ?? "localhost";
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
 import { getConfig, isDebugMode } from "./config/index.js";
 import { createTransportProvider } from "./transports/index.js";
 import { startServer } from "./server.js";
+import { BrowserPool } from "./services/browserPool.js";
 import { logger } from "./utils/logger.js";
 
 /**
@@ -32,6 +33,9 @@ async function main() {
 
     // Start server
     await startServer(transportProvider);
+
+    // Pre-warm browser pool
+    await BrowserPool.getInstance().warm();
 
     logger.info("[Setup] Server started");
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,29 +55,44 @@ function createServer() {
  */
 function setupProcessHandlers(transportProvider: TransportProvider): void {
   // Handle SIGINT signal (Ctrl+C)
-  process.on("SIGINT", async () => {
+  process.on("SIGINT", () => {
     logger.info("[Server] Received SIGINT signal, gracefully shutting down...");
-    await transportProvider.close();
-    process.exit(0);
+    transportProvider
+      .close()
+      .then(() => process.exit(0))
+      .catch((err) => {
+        logger.error(`[Server] Shutdown error: ${err.message}`);
+        process.exit(1);
+      });
   });
 
   // Handle SIGTERM signal
-  process.on("SIGTERM", async () => {
+  process.on("SIGTERM", () => {
     logger.info(
       "[Server] Received SIGTERM signal, gracefully shutting down..."
     );
-    await transportProvider.close();
-    process.exit(0);
+    transportProvider
+      .close()
+      .then(() => process.exit(0))
+      .catch((err) => {
+        logger.error(`[Server] Shutdown error: ${err.message}`);
+        process.exit(1);
+      });
   });
 
   // Handle uncaught exceptions
-  process.on("uncaughtException", async (error) => {
+  process.on("uncaughtException", (error) => {
     logger.error(`[Server] Uncaught exception: ${error.message}`);
     if (error.stack) {
       logger.error(error.stack);
     }
-    await transportProvider.close();
-    process.exit(1);
+    transportProvider
+      .close()
+      .then(() => process.exit(1))
+      .catch((err) => {
+        logger.error(`[Server] Shutdown error: ${err.message}`);
+        process.exit(1);
+      });
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { tools, toolHandlers } from "./tools/index.js";
 import { TransportProvider } from "./transports/types.js";
+import { BrowserPool } from "./services/browserPool.js";
 import { logger } from "./utils/logger.js";
 
 /**
@@ -56,6 +57,7 @@ function createServer() {
 function setupProcessHandlers(transportProvider: TransportProvider): void {
   const gracefulShutdown = async () => {
     logger.info("[Server] Starting graceful shutdown...");
+    await BrowserPool.getInstance().shutdown();
     return transportProvider.close();
   };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,6 @@ import {
 import { tools, toolHandlers } from "./tools/index.js";
 import { TransportProvider } from "./transports/types.js";
 import { logger } from "./utils/logger.js";
-import { BrowserPoolService } from "./services/browserPoolService.js";
 
 /**
  * Create MCP server instance
@@ -44,7 +43,7 @@ function createServer() {
       throw new Error(`Unknown tool: ${toolName}`);
     }
 
-    return handler(request.params.arguments);
+    return handler(request.params.arguments ?? {});
   });
 
   return server;
@@ -57,15 +56,6 @@ function createServer() {
 function setupProcessHandlers(transportProvider: TransportProvider): void {
   const gracefulShutdown = async () => {
     logger.info("[Server] Starting graceful shutdown...");
-    const pool = BrowserPoolService.getInstance();
-
-    try {
-      await pool.shutdown();
-      logger.info("[Server] Browser pool shut down successfully");
-    } catch (err: any) {
-      logger.error(`[Server] Error shutting down pool: ${err.message}`);
-    }
-
     return transportProvider.close();
   };
 
@@ -74,8 +64,9 @@ function setupProcessHandlers(transportProvider: TransportProvider): void {
     logger.info("[Server] Received SIGINT signal, gracefully shutting down...");
     gracefulShutdown()
       .then(() => process.exit(0))
-      .catch((err) => {
-        logger.error(`[Server] Shutdown error: ${err.message}`);
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[Server] Shutdown error: ${msg}`);
         process.exit(1);
       });
   });
@@ -87,8 +78,9 @@ function setupProcessHandlers(transportProvider: TransportProvider): void {
     );
     gracefulShutdown()
       .then(() => process.exit(0))
-      .catch((err) => {
-        logger.error(`[Server] Shutdown error: ${err.message}`);
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[Server] Shutdown error: ${msg}`);
         process.exit(1);
       });
   });
@@ -101,8 +93,9 @@ function setupProcessHandlers(transportProvider: TransportProvider): void {
     }
     gracefulShutdown()
       .then(() => process.exit(1))
-      .catch((err) => {
-        logger.error(`[Server] Shutdown error: ${err.message}`);
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[Server] Shutdown error: ${msg}`);
         process.exit(1);
       });
   });
@@ -116,18 +109,17 @@ export async function startServer(
   transportProvider: TransportProvider
 ): Promise<void> {
   try {
-    const server = createServer();
     logger.info("[Server] Starting MCP server...");
-
-    // Connect to transport
-    await transportProvider.connect(server);
+    // Connect to transport (pass factory so HTTP can create per-session servers)
+    await transportProvider.connect(createServer);
 
     logger.info("[Server] MCP server started");
 
     // Set up process termination handlers
     setupProcessHandlers(transportProvider);
-  } catch (error: any) {
-    logger.error(`[Server] Failed to start MCP server: ${error.message}`);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.error(`[Server] Failed to start MCP server: ${msg}`);
     throw error;
   }
 }

--- a/src/services/browserPool.ts
+++ b/src/services/browserPool.ts
@@ -1,0 +1,220 @@
+import { Browser, chromium } from "playwright";
+import { logger } from "../utils/logger.js";
+
+export interface BrowserHandle {
+  browser: Browser;
+  release(): Promise<void>;
+}
+
+interface PooledBrowser {
+  browser: Browser;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class BrowserPool {
+  private static instance: BrowserPool | null = null;
+
+  private idle: PooledBrowser[] = [];
+  private inUse = 0;
+  private poolSize: number;
+  private warmCount: number;
+  private idleTimeoutMs: number;
+  private shutdownRequested = false;
+
+  private constructor() {
+    this.poolSize = this.envInt("BROWSER_POOL_SIZE", 3);
+    this.warmCount = Math.min(
+      this.envInt("BROWSER_POOL_WARM", 1),
+      this.poolSize,
+    );
+    this.idleTimeoutMs = this.envInt("BROWSER_IDLE_TIMEOUT", 300) * 1000;
+  }
+
+  static getInstance(): BrowserPool {
+    if (!BrowserPool.instance) {
+      BrowserPool.instance = new BrowserPool();
+    }
+    return BrowserPool.instance;
+  }
+
+  /** Pre-warm browsers up to warmCount. Call after server starts. */
+  async warm(): Promise<void> {
+    const toCreate = this.warmCount - this.idle.length;
+    for (let i = 0; i < toCreate; i++) {
+      try {
+        const browser = await this.launchBrowser();
+        this.addToIdle(browser);
+        logger.info(`[BrowserPool] Warmed browser ${i + 1}/${toCreate}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[BrowserPool] Failed to warm browser: ${msg}`);
+      }
+    }
+  }
+
+  /**
+   * Acquire a browser from the pool.
+   * - If debug is true, creates a temporary visible browser (never pooled).
+   * - Otherwise returns a pooled browser, creating or bursting as needed.
+   */
+  async acquire(debug = false): Promise<BrowserHandle> {
+    if (this.shutdownRequested) {
+      throw new Error("BrowserPool is shutting down");
+    }
+
+    // Debug requests always get a temporary visible browser
+    if (debug) {
+      const browser = await this.launchBrowser(false);
+      logger.debug("[BrowserPool] Created burst browser for debug request");
+      return {
+        browser,
+        release: async () => {
+          // Debug browsers stay open — don't close
+          logger.debug("[BrowserPool] Debug browser kept open");
+        },
+      };
+    }
+
+    // Try to get an idle browser
+    while (this.idle.length > 0) {
+      const pooled = this.idle.pop()!;
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+
+      if (pooled.browser.isConnected()) {
+        this.inUse++;
+        logger.debug(
+          `[BrowserPool] Acquired idle browser (idle=${this.idle.length} inUse=${this.inUse})`,
+        );
+        return this.createHandle(pooled.browser, false);
+      }
+      // Dead browser — discard and try next
+      logger.warn("[BrowserPool] Discarded dead browser from pool");
+    }
+
+    // No idle browsers — create a new one
+    const isBurst = this.inUse >= this.poolSize;
+    const browser = await this.launchBrowser();
+    this.inUse++;
+
+    if (isBurst) {
+      logger.info(
+        `[BrowserPool] Created burst browser (inUse=${this.inUse}, poolSize=${this.poolSize})`,
+      );
+    } else {
+      logger.debug(
+        `[BrowserPool] Created new pooled browser (idle=${this.idle.length} inUse=${this.inUse})`,
+      );
+    }
+
+    return this.createHandle(browser, isBurst);
+  }
+
+  /** Graceful shutdown — close all browsers. */
+  async shutdown(): Promise<void> {
+    this.shutdownRequested = true;
+    logger.info("[BrowserPool] Shutting down...");
+
+    // Clear idle timers and close idle browsers
+    for (const pooled of this.idle) {
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+      await this.closeBrowser(pooled.browser);
+    }
+    this.idle = [];
+
+    // In-use browsers will be closed when their handles are released
+    // (release() checks shutdownRequested)
+    logger.info("[BrowserPool] Shutdown complete");
+  }
+
+  /** Reset singleton — for testing only. */
+  static resetInstance(): void {
+    BrowserPool.instance = null;
+  }
+
+  private createHandle(browser: Browser, isBurst: boolean): BrowserHandle {
+    let released = false;
+    return {
+      browser,
+      release: async () => {
+        if (released) return;
+        released = true;
+        this.inUse--;
+
+        if (isBurst || this.shutdownRequested) {
+          await this.closeBrowser(browser);
+          if (isBurst) {
+            logger.debug("[BrowserPool] Destroyed burst browser");
+          }
+          return;
+        }
+
+        if (browser.isConnected()) {
+          this.addToIdle(browser);
+          logger.debug(
+            `[BrowserPool] Released browser to pool (idle=${this.idle.length} inUse=${this.inUse})`,
+          );
+        } else {
+          logger.warn("[BrowserPool] Released browser was dead, discarding");
+        }
+      },
+    };
+  }
+
+  private addToIdle(browser: Browser): void {
+    const pooled: PooledBrowser = { browser, idleTimer: null };
+
+    // Only set idle timer if we're above warm count
+    if (this.idle.length >= this.warmCount) {
+      pooled.idleTimer = setTimeout(() => {
+        const idx = this.idle.indexOf(pooled);
+        if (idx !== -1 && this.idle.length > this.warmCount) {
+          this.idle.splice(idx, 1);
+          this.closeBrowser(pooled.browser);
+          logger.info(
+            `[BrowserPool] Evicted idle browser (idle=${this.idle.length})`,
+          );
+        }
+      }, this.idleTimeoutMs);
+    }
+
+    this.idle.push(pooled);
+  }
+
+  private async launchBrowser(headless = true): Promise<Browser> {
+    return chromium.launch({
+      headless,
+      args: [
+        "--disable-blink-features=AutomationControlled",
+        "--disable-features=IsolateOrigins,site-per-process",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-webgl",
+        "--disable-infobars",
+        "--disable-extensions",
+      ],
+    });
+  }
+
+  private async closeBrowser(browser: Browser): Promise<void> {
+    try {
+      if (browser.isConnected()) await browser.close();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[BrowserPool] Failed to close browser: ${msg}`);
+    }
+  }
+
+  private envInt(name: string, defaultVal: number): number {
+    const val = process.env[name];
+    if (!val) return defaultVal;
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      logger.warn(
+        `[BrowserPool] Invalid ${name}=${val}, using default ${defaultVal}`,
+      );
+      return defaultVal;
+    }
+    return parsed;
+  }
+}

--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -229,12 +229,17 @@ export class BrowserService {
   /**
    * Clean up resources
    */
-  public async cleanup(browser: Browser | null, page: Page | null): Promise<void> {
+  public async cleanup(browser: Browser | null, page: Page | null, context: BrowserContext | null = null): Promise<void> {
     if (!this.isDebugMode) {
       if (page) {
         await page
           .close()
           .catch((e) => logger.error(`Failed to close page: ${e.message}`));
+      }
+      if (context) {
+        await context
+          .close()
+          .catch((e) => logger.error(`Failed to close context: ${e.message}`));
       }
       if (browser) {
         await browser

--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -1,9 +1,10 @@
-import { Browser, BrowserContext, Page, chromium } from "playwright";
-import { logger } from "../utils/logger.js";
+import { Browser, BrowserContext, Page } from "playwright";
 import { FetchOptions } from "../types/index.js";
 
 /**
- * Service for managing browser instances with anti-detection features
+ * Service for managing browser contexts and pages with anti-detection features.
+ * Browser lifecycle is now owned by BrowserPool — this service handles
+ * context creation, page creation, and stealth configuration.
  */
 export class BrowserService {
   private options: FetchOptions;
@@ -12,7 +13,7 @@ export class BrowserService {
   constructor(options: FetchOptions) {
     this.options = options;
     this.isDebugMode = process.argv.includes("--debug");
-    
+
     // Debug mode from options takes precedence over command line flag
     if (options.debug !== undefined) {
       this.isDebugMode = options.debug;
@@ -69,31 +70,31 @@ export class BrowserService {
       Object.defineProperty(navigator, 'webdriver', {
         get: () => false,
       });
-      
+
       // Remove automation fingerprints
       delete (window as any).cdc_adoQpoasnfa76pfcZLmcfl_Array;
       delete (window as any).cdc_adoQpoasnfa76pfcZLmcfl_Promise;
       delete (window as any).cdc_adoQpoasnfa76pfcZLmcfl_Symbol;
-      
+
       // Add Chrome object for fingerprinting evasion
       const chrome = {
         runtime: {},
       };
-      
+
       // Add fingerprint characteristics
       (window as any).chrome = chrome;
-      
+
       // Modify screen and navigator properties
       Object.defineProperty(screen, 'width', { value: window.innerWidth });
       Object.defineProperty(screen, 'height', { value: window.innerHeight });
       Object.defineProperty(screen, 'availWidth', { value: window.innerWidth });
       Object.defineProperty(screen, 'availHeight', { value: window.innerHeight });
-      
+
       // Add language features
       Object.defineProperty(navigator, 'languages', {
         get: () => ['en-US', 'en'],
       });
-      
+
       // Simulate random number of plugins
       Object.defineProperty(navigator, 'plugins', {
         get: () => {
@@ -128,60 +129,11 @@ export class BrowserService {
   }
 
   /**
-   * Create a new stealth browser instance
-   */
-  public async createBrowser(): Promise<Browser> {
-    const viewport = this.getRandomViewport();
-
-    try {
-      return await chromium.launch({
-        headless: !this.isDebugMode,
-        args: [
-          '--disable-blink-features=AutomationControlled',
-          '--disable-features=IsolateOrigins,site-per-process',
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-webgl',
-          '--disable-infobars',
-          '--window-size=' + viewport.width + ',' + viewport.height,
-          '--disable-extensions'
-        ]
-      });
-    } catch (error: any) {
-      // Check if the error is related to missing browser installation
-      if (this.isBrowserNotInstalledError(error)) {
-        const enhancedError = new Error(
-          `Browser not installed. ${error.message}\n\n` +
-          `💡 To fix this issue, please call the 'browser_install' tool to install the required browser binaries.`
-        );
-        enhancedError.name = 'BrowserNotInstalledError';
-        throw enhancedError;
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Check if error is related to browser not being installed
-   */
-  private isBrowserNotInstalledError(error: any): boolean {
-    const errorMessage = error.message?.toLowerCase() || '';
-
-    return errorMessage.includes('executable doesn\'t exist') ||
-           errorMessage.includes('browser not found') ||
-           errorMessage.includes('could not find browser') ||
-           errorMessage.includes('failed to launch browser') ||
-           errorMessage.includes('browser executable not found') ||
-           errorMessage.includes('chromium browser not found');
-  }
-
-  /**
    * Create a new browser context with stealth configurations
    */
   public async createContext(browser: Browser): Promise<{ context: BrowserContext, viewport: {width: number, height: number} }> {
     const viewport = this.getRandomViewport();
-    
+
     const context = await browser.newContext({
       javaScriptEnabled: true,
       ignoreHTTPSErrors: true,
@@ -211,10 +163,10 @@ export class BrowserService {
 
     // Set up anti-detection measures
     await this.setupAntiDetection(context);
-    
+
     // Configure media handling
     await this.setupMediaHandling(context);
-    
+
     return { context, viewport };
   }
 
@@ -224,28 +176,5 @@ export class BrowserService {
   public async createPage(context: BrowserContext, _viewport: {width: number, height: number}): Promise<Page> {
     const page = await context.newPage();
     return page;
-  }
-
-  /**
-   * Clean up resources
-   */
-  public async cleanup(browser: Browser | null, page: Page | null, context: BrowserContext | null = null): Promise<void> {
-    if (!this.isDebugMode) {
-      if (page) {
-        await page
-          .close()
-          .catch((e) => logger.error(`Failed to close page: ${e.message}`));
-      }
-      if (context) {
-        await context
-          .close()
-          .catch((e) => logger.error(`Failed to close context: ${e.message}`));
-      }
-      if (browser) {
-        await browser
-          .close()
-          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
-      }
-    }
   }
 }

--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -43,7 +43,7 @@ export class BrowserService {
       // Safari
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15",
     ];
-    return userAgents[Math.floor(Math.random() * userAgents.length)];
+    return userAgents[Math.floor(Math.random() * userAgents.length)] ?? userAgents[0]!;
   }
 
   /**
@@ -57,7 +57,7 @@ export class BrowserService {
       { width: 1440, height: 900 },
       { width: 1280, height: 720 },
     ];
-    return viewports[Math.floor(Math.random() * viewports.length)];
+    return viewports[Math.floor(Math.random() * viewports.length)] ?? viewports[0]!;
   }
 
   /**
@@ -221,7 +221,7 @@ export class BrowserService {
   /**
    * Create a new page
    */
-  public async createPage(context: BrowserContext, viewport: {width: number, height: number}): Promise<Page> {
+  public async createPage(context: BrowserContext, _viewport: {width: number, height: number}): Promise<Page> {
     const page = await context.newPage();
     return page;
   }

--- a/src/services/webContentProcessor.ts
+++ b/src/services/webContentProcessor.ts
@@ -1,6 +1,9 @@
-import { JSDOM } from "jsdom";
+import { JSDOM, VirtualConsole } from "jsdom";
 import { Readability } from "@mozilla/readability";
 import TurndownService from "turndown";
+// @ts-ignore
+import { gfm } from "turndown-plugin-gfm";
+import { Page } from "playwright";
 import { FetchOptions, FetchResult } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 
@@ -13,7 +16,7 @@ export class WebContentProcessor {
     this.logPrefix = logPrefix;
   }
 
-  async processPageContent(page: any, url: string): Promise<FetchResult> {
+  async processPageContent(page: Page, url: string): Promise<FetchResult> {
     try {
       // Set timeout
       page.setDefaultTimeout(this.options.timeout);
@@ -25,33 +28,35 @@ export class WebContentProcessor {
           timeout: this.options.timeout,
           waitUntil: this.options.waitUntil,
         });
-      } catch (gotoError: any) {
+      } catch (gotoError: unknown) {
+        const gotoMessage = gotoError instanceof Error ? gotoError.message : String(gotoError);
         // If it's a timeout error, try to retrieve page content
-        if (gotoError.message.includes("Timeout") || gotoError.message.includes("timeout")) {
-          logger.warn(`${this.logPrefix} Navigation timeout: ${gotoError.message}. Attempting to retrieve content anyway...`);
-          
+        if (gotoMessage.includes("Timeout") || gotoMessage.includes("timeout")) {
+          logger.warn(`${this.logPrefix} Navigation timeout: ${gotoMessage}. Attempting to retrieve content anyway...`);
+
           // Try to retrieve page content
           try {
             // Directly get page information without waiting for page stability
             const { pageTitle, html } = await this.safelyGetPageInfo(page, url);
-            
+
             // If content is retrieved, process and return it
             if (html && html.trim().length > 0) {
               logger.info(`${this.logPrefix} Successfully retrieved content despite timeout, length: ${html.length}`);
-              
+
               const processedContent = await this.processContent(html, url);
               const formattedContent = `Title: ${pageTitle}\nURL: ${url}\nContent:\n\n${processedContent}`;
-              
+
               return {
                 success: true,
                 content: formattedContent,
               };
             }
-          } catch (retrieveError: any) {
-            logger.error(`${this.logPrefix} Failed to retrieve content after timeout: ${retrieveError.message}`);
+          } catch (retrieveError: unknown) {
+            const retrieveMessage = retrieveError instanceof Error ? retrieveError.message : String(retrieveError);
+            logger.error(`${this.logPrefix} Failed to retrieve content after timeout: ${retrieveMessage}`);
           }
         }
-        
+
         // If unable to retrieve content or it's not a timeout error, continue to throw the original error
         throw gotoError;
       }
@@ -83,15 +88,17 @@ export class WebContentProcessor {
                 `${this.logPrefix} Page navigated/redirected successfully`
               );
             })
-            .catch((e) => {
+            .catch((e: unknown) => {
+              const msg = e instanceof Error ? e.message : String(e);
               // If timeout occurs but page may have already loaded, we can continue
               logger.warn(
-                `${this.logPrefix} No navigation occurred or navigation timeout: ${e.message}`
+                `${this.logPrefix} No navigation occurred or navigation timeout: ${msg}`
               );
             });
-        } catch (navError: any) {
+        } catch (navError: unknown) {
+          const navMessage = navError instanceof Error ? navError.message : String(navError);
           logger.error(
-            `${this.logPrefix} Error waiting for navigation: ${navError.message}`
+            `${this.logPrefix} Error waiting for navigation: ${navMessage}`
           );
           // Continue processing the page even if there are navigation issues
         }
@@ -99,7 +106,7 @@ export class WebContentProcessor {
 
       // Wait for the page to stabilize before getting content
       await this.ensurePageStability(page);
-      
+
       // Safely retrieve page title and content
       const { pageTitle, html } = await this.safelyGetPageInfo(page, url);
 
@@ -138,57 +145,57 @@ export class WebContentProcessor {
     }
   }
 
-  // Added method: Ensure page stability
-  private async ensurePageStability(page: any): Promise<void> {
+  // Ensure page stability before content extraction
+  private async ensurePageStability(page: Page): Promise<void> {
     try {
       // Check if there are ongoing network requests or navigation
       await page.waitForFunction(
         () => {
           return window.document.readyState === 'complete';
-        }, 
+        },
         { timeout: this.options.timeout }
       );
-      
+
       // Wait an extra short time to ensure page stability
-      await page.waitForTimeout(500);
-      
+      await new Promise(resolve => setTimeout(resolve, 500));
+
       logger.info(`${this.logPrefix} Page has stabilized`);
     } catch (error) {
       logger.warn(`${this.logPrefix} Error ensuring page stability: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
-  // Added method: Safely get page information (title and HTML content)
-  private async safelyGetPageInfo(page: any, url: string, retries = 3): Promise<{pageTitle: string, html: string}> {
+  // Safely get page information (title and HTML content) with retries
+  private async safelyGetPageInfo(page: Page, _url: string, retries = 3): Promise<{pageTitle: string, html: string}> {
     let pageTitle = "Untitled";
     let html = "";
     let attempt = 0;
-    
+
     while (attempt < retries) {
       try {
         attempt++;
-        
+
         // Get page title
         pageTitle = await page.title();
         logger.info(`${this.logPrefix} Page title: ${pageTitle}`);
-        
+
         // Get HTML content
         html = await page.content();
-        
+
         // If successfully retrieved, exit the loop
         return { pageTitle, html };
-        
+
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        
+
         // Check if it's an "execution context was destroyed" error
         if (errorMessage.includes("Execution context was destroyed") && attempt < retries) {
           logger.warn(`${this.logPrefix} Context destroyed, waiting for navigation to complete (attempt ${attempt}/${retries})...`);
-          
+
           // Wait for page to stabilize
           await new Promise(resolve => setTimeout(resolve, 1000));
           await this.ensurePageStability(page);
-          
+
           // If it's the last retry attempt, log the error but continue
           if (attempt === retries) {
             logger.error(`${this.logPrefix} Failed to get page info after ${retries} attempts`);
@@ -200,7 +207,7 @@ export class WebContentProcessor {
         }
       }
     }
-    
+
     return { pageTitle, html };
   }
 
@@ -210,7 +217,8 @@ export class WebContentProcessor {
     // Extract main content if needed
     if (this.options.extractContent) {
       logger.info(`${this.logPrefix} Extracting main content`);
-      const dom = new JSDOM(html, { url });
+      const virtualConsole = new VirtualConsole();
+      const dom = new JSDOM(html, { url, virtualConsole });
       const reader = new Readability(dom.window.document);
       const article = reader.parse();
 
@@ -231,6 +239,7 @@ export class WebContentProcessor {
     if (!this.options.returnHtml) {
       logger.info(`${this.logPrefix} Converting to Markdown`);
       const turndownService = new TurndownService();
+      turndownService.use(gfm);  // Enable GFM table support
       processedContent = turndownService.turndown(contentToProcess);
       logger.info(
         `${this.logPrefix} Successfully converted to Markdown, length: ${processedContent.length}`

--- a/src/tools/browserInstall.ts
+++ b/src/tools/browserInstall.ts
@@ -2,6 +2,7 @@ import { spawn } from "child_process";
 import { createRequire } from "module";
 import { existsSync } from "fs";
 import { logger } from "../utils/logger.js";
+import { BrowserInstallArgsSchema } from "../types/index.js";
 
 // Create require for ES modules
 const require = createRequire(import.meta.url);
@@ -33,9 +34,8 @@ export const browserInstallTool = {
 /**
  * Implementation of the browser_install tool
  */
-export async function browserInstall(args: any) {
-  const withDeps = args?.withDeps === true;
-  const force = args?.force === true;
+export async function browserInstall(args: Record<string, unknown> = {}) {
+  const { withDeps, force } = BrowserInstallArgsSchema.parse(args);
 
   logger.info("[BrowserInstall] Starting installation of Chromium browser...");
 

--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -1,4 +1,4 @@
-import { Browser, Page } from "playwright";
+import { Browser, BrowserContext, Page } from "playwright";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
 import { FetchOptions } from "../types/index.js";
@@ -95,11 +95,12 @@ export async function fetchUrl(args: any) {
 
   // Create browser service
   const browserService = new BrowserService(options);
-  
+
   // Create content processor
   const processor = new WebContentProcessor(options, "[FetchURL]");
   let browser: Browser | null = null;
   let page: Page | null = null;
+  let context: BrowserContext | null = null;
 
   if (browserService.isInDebugMode()) {
     logger.debug(`Debug mode enabled for URL: ${url}`);
@@ -108,9 +109,11 @@ export async function fetchUrl(args: any) {
   try {
     // Create a stealth browser with anti-detection measures
     browser = await browserService.createBrowser();
-    
+
     // Create a stealth browser context
-    const { context, viewport } = await browserService.createContext(browser);
+    const contextResult = await browserService.createContext(browser);
+    context = contextResult.context;
+    const viewport = contextResult.viewport;
 
     // Create a new page with human-like behavior
     page = await browserService.createPage(context, viewport);
@@ -123,8 +126,8 @@ export async function fetchUrl(args: any) {
     };
   } finally {
     // Clean up resources
-    await browserService.cleanup(browser, page);
-    
+    await browserService.cleanup(browser, page, context);
+
     if (browserService.isInDebugMode()) {
       logger.debug(`Browser and page kept open for debugging. URL: ${url}`);
     }

--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -1,9 +1,9 @@
-import { Browser, BrowserContext, Page } from "playwright";
+import { Browser, Page } from "playwright";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
-import { BrowserPoolService } from "../services/browserPoolService.js";
-import { FetchOptions } from "../types/index.js";
+import { FetchUrlArgsSchema, FetchOptionsSchema } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { validateUrlProtocol } from "../utils/urlValidator.js";
 
 /**
  * Tool definition for fetch_url
@@ -16,7 +16,8 @@ export const fetchUrlTool = {
     properties: {
       url: {
         type: "string",
-        description: "URL to fetch. Make sure to include the schema (http:// or https:// if not defined, preferring https for most cases)",
+        description:
+          "URL to fetch. Make sure to include the schema (http:// or https:// if not defined, preferring https for most cases)",
       },
       timeout: {
         type: "number",
@@ -66,53 +67,45 @@ export const fetchUrlTool = {
     },
     required: ["url"],
   },
+  annotations: {
+    title: "Fetch URL",
+    readOnlyHint: true,
+  },
 };
 
 /**
  * Implementation of the fetch_url tool
  */
-export async function fetchUrl(args: any) {
-  const url = String(args?.url || "");
-  if (!url) {
-    logger.error(`URL parameter missing`);
-    throw new Error("URL parameter is required");
-  }
+export async function fetchUrl(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlArgsSchema.parse(args);
+  const url = parsed.url;
 
-  const options: FetchOptions = {
-    timeout: Number(args?.timeout) || 30000,
-    waitUntil: String(args?.waitUntil || "load") as
-      | "load"
-      | "domcontentloaded"
-      | "networkidle"
-      | "commit",
-    extractContent: args?.extractContent !== false,
-    maxLength: Number(args?.maxLength) || 0,
-    returnHtml: args?.returnHtml === true,
-    waitForNavigation: args?.waitForNavigation === true,
-    navigationTimeout: Number(args?.navigationTimeout) || 10000,
-    disableMedia: args?.disableMedia !== false,
-    debug: args?.debug,
-  };
+  // Validate URL protocol for security (only allow HTTP and HTTPS)
+  validateUrlProtocol(url);
+
+  const options = FetchOptionsSchema.parse(parsed);
 
   // Create browser service
   const browserService = new BrowserService(options);
 
   // Create content processor
   const processor = new WebContentProcessor(options, "[FetchURL]");
+  let browser: Browser | null = null;
   let page: Page | null = null;
-  const pool = BrowserPoolService.getInstance();
-  let handle = null as any;
 
   if (browserService.isInDebugMode()) {
     logger.debug(`Debug mode enabled for URL: ${url}`);
   }
 
   try {
-    // Acquire browser from pool
-    handle = await pool.acquireBrowser(browserService, options);
+    // Create a stealth browser with anti-detection measures
+    browser = await browserService.createBrowser();
+
+    // Create a stealth browser context
+    const { context, viewport } = await browserService.createContext(browser);
 
     // Create a new page with human-like behavior
-    page = await browserService.createPage(handle.context, handle.viewport);
+    page = await browserService.createPage(context, viewport);
 
     // Process page content
     const result = await processor.processPageContent(page, url);
@@ -121,17 +114,8 @@ export async function fetchUrl(args: any) {
       content: [{ type: "text", text: result.content }],
     };
   } finally {
-    // Clean up page
-    if (page && !browserService.isInDebugMode()) {
-      await page
-        .close()
-        .catch((e) => logger.error(`Failed to close page: ${e.message}`));
-    }
-
-    // Release browser back to pool
-    if (handle) {
-      await handle.releaseContext();
-    }
+    // Clean up resources
+    await browserService.cleanup(browser, page);
 
     if (browserService.isInDebugMode()) {
       logger.debug(`Browser and page kept open for debugging. URL: ${url}`);

--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -1,6 +1,6 @@
-import { Browser, Page } from "playwright";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
 import { FetchUrlArgsSchema, FetchOptionsSchema } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { validateUrlProtocol } from "../utils/urlValidator.js";
@@ -80,45 +80,34 @@ export async function fetchUrl(args: Record<string, unknown> = {}) {
   const parsed = FetchUrlArgsSchema.parse(args);
   const url = parsed.url;
 
-  // Validate URL protocol for security (only allow HTTP and HTTPS)
   validateUrlProtocol(url);
 
   const options = FetchOptionsSchema.parse(parsed);
-
-  // Create browser service
   const browserService = new BrowserService(options);
-
-  // Create content processor
   const processor = new WebContentProcessor(options, "[FetchURL]");
-  let browser: Browser | null = null;
-  let page: Page | null = null;
 
-  if (browserService.isInDebugMode()) {
-    logger.debug(`Debug mode enabled for URL: ${url}`);
-  }
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
 
   try {
-    // Create a stealth browser with anti-detection measures
-    browser = await browserService.createBrowser();
+    handle = await pool.acquire(browserService.isInDebugMode());
+    const { context, viewport } = await browserService.createContext(handle.browser);
 
-    // Create a stealth browser context
-    const { context, viewport } = await browserService.createContext(browser);
+    try {
+      const page = await browserService.createPage(context, viewport);
+      const result = await processor.processPageContent(page, url);
 
-    // Create a new page with human-like behavior
-    page = await browserService.createPage(context, viewport);
-
-    // Process page content
-    const result = await processor.processPageContent(page, url);
-
-    return {
-      content: [{ type: "text", text: result.content }],
-    };
-  } finally {
-    // Clean up resources
-    await browserService.cleanup(browser, page);
-
-    if (browserService.isInDebugMode()) {
-      logger.debug(`Browser and page kept open for debugging. URL: ${url}`);
+      return {
+        content: [{ type: "text", text: result.content }],
+      };
+    } finally {
+      if (!browserService.isInDebugMode()) {
+        await context.close().catch((e: Error) =>
+          logger.error(`[FetchURL] Failed to close context: ${e.message}`)
+        );
+      }
     }
+  } finally {
+    if (handle) await handle.release();
   }
 }

--- a/src/tools/fetchUrls.ts
+++ b/src/tools/fetchUrls.ts
@@ -1,7 +1,7 @@
-import { Browser } from "playwright";
 import pLimit from "p-limit";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
 import { FetchUrlsArgsSchema, FetchOptionsSchema, FetchResult } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { validateUrlsProtocol } from "../utils/urlValidator.js";
@@ -83,12 +83,10 @@ export async function fetchUrls(args: Record<string, unknown> = {}) {
   const parsed = FetchUrlsArgsSchema.parse(args);
   const urls = parsed.urls;
 
-  // Validate all URL protocols for security (only allow HTTP and HTTPS)
   validateUrlsProtocol(urls);
 
   const options = FetchOptionsSchema.parse(parsed);
 
-  // Configure concurrency limit for page creation
   let maxConcurrentPages = parseInt(
     process.env.MAX_CONCURRENT_PAGES || "5",
     10
@@ -101,33 +99,36 @@ export async function fetchUrls(args: Record<string, unknown> = {}) {
   }
   const limit = pLimit(maxConcurrentPages);
 
-  // Create browser service
   const browserService = new BrowserService(options);
+  const processor = new WebContentProcessor(options, "[FetchURLs]");
 
-  if (browserService.isInDebugMode()) {
-    logger.debug(`Debug mode enabled for URLs: ${urls.join(", ")}`);
-  }
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
 
-  let browser: Browser | null = null;
   try {
-    browser = await browserService.createBrowser();
-    const { context, viewport } = await browserService.createContext(browser);
-    const processor = new WebContentProcessor(options, "[FetchURLs]");
+    handle = await pool.acquire(browserService.isInDebugMode());
 
     const settled = await Promise.allSettled(
       urls.map((url, index) =>
         limit(async () => {
-          const page = await browserService.createPage(context, viewport);
+          const { context, viewport } = await browserService.createContext(handle!.browser);
           try {
-            const result = await processor.processPageContent(page, url);
-            return { index, ...result } as FetchResult;
+            const page = await browserService.createPage(context, viewport);
+            try {
+              const result = await processor.processPageContent(page, url);
+              return { index, ...result } as FetchResult;
+            } finally {
+              if (!browserService.isInDebugMode()) {
+                await page.close().catch((e: Error) =>
+                  logger.error(`[FetchURLs] Failed to close page: ${e.message}`)
+                );
+              }
+            }
           } finally {
             if (!browserService.isInDebugMode()) {
-              await page
-                .close()
-                .catch((e) => logger.error(`Failed to close page: ${e.message}`));
-            } else {
-              logger.debug(`Page kept open for debugging. URL: ${url}`);
+              await context.close().catch((e: Error) =>
+                logger.error(`[FetchURLs] Failed to close context: ${e.message}`)
+              );
             }
           }
         })
@@ -162,13 +163,6 @@ export async function fetchUrls(args: Record<string, unknown> = {}) {
       content: [{ type: "text", text: combinedResults }],
     };
   } finally {
-    if (!browserService.isInDebugMode()) {
-      if (browser)
-        await browser
-          .close()
-          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
-    } else {
-      logger.debug(`Browser kept open for debugging. URLs: ${urls.join(", ")}`);
-    }
+    if (handle) await handle.release();
   }
 }

--- a/src/tools/fetchUrls.ts
+++ b/src/tools/fetchUrls.ts
@@ -1,10 +1,10 @@
-import { Browser, BrowserContext, Page } from "playwright";
+import { Browser } from "playwright";
 import pLimit from "p-limit";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
-import { BrowserPoolService } from "../services/browserPoolService.js";
-import { FetchOptions, FetchResult } from "../types/index.js";
+import { FetchUrlsArgsSchema, FetchOptionsSchema, FetchResult } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { validateUrlsProtocol } from "../utils/urlValidator.js";
 
 /**
  * Tool definition for fetch_urls
@@ -70,32 +70,23 @@ export const fetchUrlsTool = {
     },
     required: ["urls"],
   },
+  annotations: {
+    title: "Fetch URLs",
+    readOnlyHint: true,
+  },
 };
 
 /**
  * Implementation of the fetch_urls tool
  */
-export async function fetchUrls(args: any) {
-  const urls = (args?.urls as string[]) || [];
-  if (!urls || !Array.isArray(urls) || urls.length === 0) {
-    throw new Error("URLs parameter is required and must be a non-empty array");
-  }
+export async function fetchUrls(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlsArgsSchema.parse(args);
+  const urls = parsed.urls;
 
-  const options: FetchOptions = {
-    timeout: Number(args?.timeout) || 30000,
-    waitUntil: String(args?.waitUntil || "load") as
-      | "load"
-      | "domcontentloaded"
-      | "networkidle"
-      | "commit",
-    extractContent: args?.extractContent !== false,
-    maxLength: Number(args?.maxLength) || 0,
-    returnHtml: args?.returnHtml === true,
-    waitForNavigation: args?.waitForNavigation === true,
-    navigationTimeout: Number(args?.navigationTimeout) || 10000,
-    disableMedia: args?.disableMedia !== false,
-    debug: args?.debug,
-  };
+  // Validate all URL protocols for security (only allow HTTP and HTTPS)
+  validateUrlsProtocol(urls);
+
+  const options = FetchOptionsSchema.parse(parsed);
 
   // Configure concurrency limit for page creation
   let maxConcurrentPages = parseInt(
@@ -117,21 +108,16 @@ export async function fetchUrls(args: any) {
     logger.debug(`Debug mode enabled for URLs: ${urls.join(", ")}`);
   }
 
-  const pool = BrowserPoolService.getInstance();
-  const processor = new WebContentProcessor(options, "[FetchURLs]");
-
+  let browser: Browser | null = null;
   try {
-    const results = await Promise.all(
+    browser = await browserService.createBrowser();
+    const { context, viewport } = await browserService.createContext(browser);
+    const processor = new WebContentProcessor(options, "[FetchURLs]");
+
+    const settled = await Promise.allSettled(
       urls.map((url, index) =>
         limit(async () => {
-          const handle = await pool.acquireBrowser(browserService, options);
-
-          // Create a new page with human-like behavior
-          const page = await browserService.createPage(
-            handle.context,
-            handle.viewport
-          );
-
+          const page = await browserService.createPage(context, viewport);
           try {
             const result = await processor.processPageContent(page, url);
             return { index, ...result } as FetchResult;
@@ -139,33 +125,50 @@ export async function fetchUrls(args: any) {
             if (!browserService.isInDebugMode()) {
               await page
                 .close()
-                .catch((e) =>
-                  logger.error(`Failed to close page: ${e.message}`)
-                );
+                .catch((e) => logger.error(`Failed to close page: ${e.message}`));
             } else {
               logger.debug(`Page kept open for debugging. URL: ${url}`);
             }
-
-            // Release browser back to pool
-            await handle.releaseContext();
           }
         })
-      )
+      ),
     );
 
-    results.sort((a, b) => (a.index || 0) - (b.index || 0));
+    const results: FetchResult[] = settled.map((outcome, i) => {
+      if (outcome.status === "fulfilled") {
+        return outcome.value;
+      }
+      const errorMessage = outcome.reason instanceof Error
+        ? outcome.reason.message
+        : String(outcome.reason);
+      logger.error(`[FetchURLs] Failed to fetch URL ${urls[i]}: ${errorMessage}`);
+      return {
+        success: false,
+        content: `Title: Error\nURL: ${urls[i]}\nContent:\n\n<error>Failed to retrieve web page content: ${errorMessage}</error>`,
+        error: errorMessage,
+        index: i,
+      };
+    });
+
+    results.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
     const combinedResults = results
       .map(
         (result, i) =>
-          `[webpage ${i + 1} begin]\n${result.content}\n[webpage ${i + 1} end]`
+          `[webpage ${i + 1} begin]\n${result.content}\n[webpage ${i + 1} end]`,
       )
       .join("\n\n");
 
     return {
       content: [{ type: "text", text: combinedResults }],
     };
-  } catch (error) {
-    logger.error(`[FetchURLs] Error processing URLs: ${(error as Error).message}`);
-    throw error;
+  } finally {
+    if (!browserService.isInDebugMode()) {
+      if (browser)
+        await browser
+          .close()
+          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
+    } else {
+      logger.debug(`Browser kept open for debugging. URLs: ${urls.join(", ")}`);
+    }
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -10,7 +10,9 @@ export const tools = [
 ];
 
 // Export tool implementations
-export const toolHandlers = {
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[] }>;
+
+export const toolHandlers: Record<string, ToolHandler> = {
   [fetchUrlTool.name]: fetchUrl,
   [fetchUrlsTool.name]: fetchUrls,
   [browserInstallTool.name]: browserInstall

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,15 +1,16 @@
 import express, { Request, Response } from "express";
 import { randomUUID } from "node:crypto";
+import { Server as HttpServer } from "node:http";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { TransportProvider } from "./types.js";
+import { TransportProvider, ServerFactory } from "./types.js";
 import { logger } from "../utils/logger.js";
 
 /**
  * Check if a request is an initialization request
  */
-function isInitializeRequest(body: any): boolean {
+function isInitializeRequest(body: Record<string, unknown>): boolean {
   return body?.method === "initialize" && body?.jsonrpc === "2.0";
 }
 
@@ -19,7 +20,8 @@ function isInitializeRequest(body: any): boolean {
  */
 export class HttpTransportProvider implements TransportProvider {
   private app: express.Application;
-  private server: any; // HTTP server instance
+  private server: HttpServer | null = null;
+  private serverFactory!: ServerFactory;
   private transports: {
     streamable: Record<string, StreamableHTTPServerTransport>;
     sse: Record<string, SSEServerTransport>;
@@ -44,13 +46,17 @@ export class HttpTransportProvider implements TransportProvider {
    * Connect server to HTTP transport
    * @param server MCP server instance
    */
-  async connect(server: Server): Promise<void> {
+  async connect(serverOrFactory: Server | ServerFactory): Promise<void> {
+    this.serverFactory = typeof serverOrFactory === "function"
+      ? serverOrFactory
+      : () => serverOrFactory;
+
     logger.info(
       `[Transport] Connecting server using HTTP transport, listening on ${this.host}:${this.port}`
     );
 
     // Initialize Express routes
-    this.setupRoutes(server);
+    this.setupRoutes();
 
     // Start HTTP server
     return new Promise((resolve) => {
@@ -88,8 +94,9 @@ export class HttpTransportProvider implements TransportProvider {
 
     // Close HTTP server
     if (this.server) {
+      const httpServer = this.server;
       return new Promise((resolve, reject) => {
-        this.server.close((err: Error) => {
+        httpServer.close((err?: Error) => {
           if (err) {
             logger.error(`[Transport] Failed to close HTTP server: ${err}`);
             reject(err);
@@ -108,10 +115,10 @@ export class HttpTransportProvider implements TransportProvider {
    * Set up Express routes
    * @param mcpServer MCP server instance
    */
-  private setupRoutes(mcpServer: Server): void {
+  private setupRoutes(): void {
     // Streamable HTTP endpoint (modern MCP clients)
     this.app.post("/mcp", async (req: Request, res: Response) => {
-      await this.handleStreamableHttpRequest(mcpServer, req, res);
+      await this.handleStreamableHttpRequest(req, res);
     });
 
     // Handle GET requests (server-to-client notifications)
@@ -126,7 +133,7 @@ export class HttpTransportProvider implements TransportProvider {
 
     // SSE endpoint (legacy MCP clients)
     this.app.get("/sse", async (req: Request, res: Response) => {
-      await this.handleSseRequest(mcpServer, req, res);
+      await this.handleSseRequest(req, res);
     });
 
     // SSE message endpoint (legacy MCP clients)
@@ -157,7 +164,6 @@ export class HttpTransportProvider implements TransportProvider {
    * Handle Streamable HTTP requests
    */
   private async handleStreamableHttpRequest(
-    server: Server,
     req: Request,
     res: Response
   ): Promise<void> {
@@ -193,8 +199,8 @@ export class HttpTransportProvider implements TransportProvider {
           }
         };
 
-        // Connect to MCP server
-        await server.connect(transport);
+        // Connect to a new MCP server instance for this session
+        await this.serverFactory().connect(transport);
       } else {
         // Invalid request
         logger.error(
@@ -261,7 +267,6 @@ export class HttpTransportProvider implements TransportProvider {
    * Handle SSE requests (legacy clients)
    */
   private async handleSseRequest(
-    server: Server,
     req: Request,
     res: Response
   ): Promise<void> {
@@ -275,7 +280,7 @@ export class HttpTransportProvider implements TransportProvider {
         delete this.transports.sse[transport.sessionId];
       });
 
-      await server.connect(transport);
+      await this.serverFactory().connect(transport);
     } catch (error: any) {
       logger.error(`[Transport] Error handling SSE request: ${error.message}`);
       if (!res.headersSent) {

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,6 +1,6 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { TransportProvider } from "./types.js";
+import { TransportProvider, ServerFactory } from "./types.js";
 import { logger } from "../utils/logger.js";
 
 /**
@@ -12,9 +12,12 @@ export class StdioTransportProvider implements TransportProvider {
 
   /**
    * Connect server to Stdio transport
-   * @param server MCP server instance
+   * @param serverOrFactory MCP server instance or factory for per-session servers
    */
-  async connect(server: Server): Promise<void> {
+  async connect(serverOrFactory: Server | ServerFactory): Promise<void> {
+    const server = typeof serverOrFactory === "function"
+      ? serverOrFactory()
+      : serverOrFactory;
     logger.info("[Transport] Connecting server using Stdio transport");
     this.transport = new StdioServerTransport();
     await server.connect(this.transport);

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -14,12 +14,14 @@ export interface TransportConfig {
  * Transport provider interface
  * Defines common methods for creating and connecting transports
  */
+export type ServerFactory = () => Server;
+
 export interface TransportProvider {
   /**
    * Connect server to transport layer
-   * @param server MCP server instance
+   * @param serverOrFactory MCP server instance or factory for per-session servers
    */
-  connect(server: Server): Promise<void>;
+  connect(serverOrFactory: Server | ServerFactory): Promise<void>;
 
   /**
    * Close transport connection

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,18 +1,37 @@
-export interface FetchOptions {
-    timeout: number;
-    waitUntil: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
-    extractContent: boolean;
-    maxLength: number;
-    returnHtml: boolean;
-    waitForNavigation: boolean;
-    navigationTimeout: number;
-    disableMedia: boolean;
-    debug?: boolean;
-  }
-  
-  export interface FetchResult {
-    success: boolean;
-    content: string;
-    error?: string;
-    index?: number;
-  }
+import { z } from "zod";
+
+export const FetchOptionsSchema = z.object({
+  timeout: z.number().positive().default(30000),
+  waitUntil: z.enum(["load", "domcontentloaded", "networkidle", "commit"]).default("load"),
+  extractContent: z.boolean().default(true),
+  maxLength: z.number().nonnegative().default(0),
+  returnHtml: z.boolean().default(false),
+  waitForNavigation: z.boolean().default(false),
+  navigationTimeout: z.number().positive().default(10000),
+  disableMedia: z.boolean().default(true),
+  debug: z.boolean().optional(),
+});
+
+export type FetchOptions = z.infer<typeof FetchOptionsSchema>;
+
+export const FetchUrlArgsSchema = z.object({
+  ...FetchOptionsSchema.partial().shape,
+  url: z.string().min(1, "URL parameter is required"),
+});
+
+export const FetchUrlsArgsSchema = z.object({
+  ...FetchOptionsSchema.partial().shape,
+  urls: z.array(z.string().min(1)).min(1, "URLs array cannot be empty"),
+});
+
+export const BrowserInstallArgsSchema = z.object({
+  withDeps: z.boolean().default(false),
+  force: z.boolean().default(false),
+});
+
+export interface FetchResult {
+  success: boolean;
+  content: string;
+  error?: string;
+  index?: number;
+}

--- a/src/utils/urlValidator.ts
+++ b/src/utils/urlValidator.ts
@@ -1,0 +1,104 @@
+import { logger } from "./logger.js";
+
+/**
+ * Security error class for URL validation failures
+ */
+export class URLSecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "URLSecurityError";
+  }
+}
+
+/**
+ * Allowed URL protocols for security
+ */
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
+
+/**
+ * Validates if a URL uses an allowed protocol (http or https only)
+ *
+ * @param url - The URL string to validate
+ * @throws {URLSecurityError} If the URL protocol is not allowed
+ * @returns The validated URL string
+ */
+export function validateUrlProtocol(url: string): string {
+  if (!url || typeof url !== "string") {
+    throw new URLSecurityError("URL must be a non-empty string");
+  }
+
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) {
+    throw new URLSecurityError("URL cannot be empty or whitespace only");
+  }
+
+  let parsedUrl: URL;
+  try {
+    // Try to parse the URL
+    parsedUrl = new URL(trimmedUrl);
+  } catch {
+    // If parsing fails, it might be a relative URL or malformed
+    throw new URLSecurityError(`Invalid URL format: ${trimmedUrl}`);
+  }
+
+  // Check if the protocol is in the allowed list
+  if (!ALLOWED_PROTOCOLS.includes(parsedUrl.protocol)) {
+    logger.error(
+      `Blocked URL with disallowed protocol: ${parsedUrl.protocol} (URL: ${trimmedUrl})`
+    );
+    throw new URLSecurityError(
+      `URL protocol "${parsedUrl.protocol}" is not allowed. Only HTTP and HTTPS protocols are permitted.`
+    );
+  }
+
+  logger.debug(`URL protocol validation passed: ${trimmedUrl}`);
+  return trimmedUrl;
+}
+
+/**
+ * Validates multiple URLs to ensure they all use allowed protocols
+ *
+ * @param urls - Array of URL strings to validate
+ * @throws {URLSecurityError} If any URL has a disallowed protocol
+ * @returns The validated URLs array
+ */
+export function validateUrlsProtocol(urls: string[]): string[] {
+  if (!Array.isArray(urls)) {
+    throw new URLSecurityError("URLs must be an array");
+  }
+
+  if (urls.length === 0) {
+    throw new URLSecurityError("URLs array cannot be empty");
+  }
+
+  const validatedUrls: string[] = [];
+  const errors: Array<{ url: string; error: string }> = [];
+
+  for (let i = 0; i < urls.length; i++) {
+    try {
+      const url = urls[i];
+      if (!url) continue;
+      const validatedUrl = validateUrlProtocol(url);
+      validatedUrls.push(validatedUrl);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      errors.push({
+        url: urls[i] ?? `(index ${i})`,
+        error: errorMessage,
+      });
+    }
+  }
+
+  // If any URL failed validation, throw an error with all failures
+  if (errors.length > 0) {
+    const errorDetails = errors
+      .map((e, idx) => `  ${idx + 1}. ${e.url}: ${e.error}`)
+      .join("\n");
+    throw new URLSecurityError(
+      `${errors.length} URL(s) failed validation:\n${errorDetails}`
+    );
+  }
+
+  return validatedUrls;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "outDir": "./build",
         "rootDir": "./src",
         "strict": true,
+        "noUncheckedIndexedAccess": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
## Summary

- Add `BrowserPool` singleton that manages headless Chromium instances with acquire/release semantics, idle eviction timers, configurable warm count, and burst overflow for load spikes
- Refactor `BrowserService` to only handle context/page creation and stealth config — browser lifecycle moves to the pool
- Refactor `fetchUrl` and `fetchUrls` to acquire from pool, create isolated contexts per request/URL, and release on completion
- Wire pool warming into server startup and graceful shutdown into SIGTERM/SIGINT handlers

## Configuration

| Env var | Default | Purpose |
|---------|---------|---------|
| `BROWSER_POOL_SIZE` | 3 | Max pooled browsers before burst |
| `BROWSER_POOL_WARM` | 1 | Pre-warmed browsers on startup |
| `BROWSER_IDLE_TIMEOUT` | 300 | Seconds before idle eviction (above warm count) |

## Test Plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean build
- [x] Smoke test: HTTP server starts, pool warms 1 browser, SIGTERM triggers pool shutdown + transport close
- [ ] CI gate (`npm run check && npm run build`)