### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ MCP server for fetch web page content using Playwright headless browser.
 
 - **Configurable Parameters**: Fine-grained control over timeouts, content extraction, and output formatting to suit different use cases.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jae-jae-fetcher-mcp).
+
 ## Quick Start
 
 Run directly with npx:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jae-jae-fetcher-mcp)