### PR TITLE
Add npm source and issue metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "fetcher-mcp",
   "version": "0.3.9",
   "description": "MCP server for fetching web content using Playwright browser",
+  "homepage": "https://github.com/jae-jae/fetcher-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jae-jae/fetcher-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jae-jae/fetcher-mcp/issues"
+  },
   "private": false,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- add npm `homepage`, `repository`, and `bugs` metadata for `fetcher-mcp`
- point the package metadata at this repository and its issue tracker

## Why
The currently published `fetcher-mcp@0.3.9` package only returns `name` and `version` for:

```sh
npm view fetcher-mcp@0.3.9 name version homepage repository bugs --json
```

Adding these fields makes the README, source repository, and issue tracker discoverable from npm and package metadata tools.

## Validation
```sh
npm view fetcher-mcp@0.3.9 name version homepage repository bugs --json
node -e "const p=require('./package.json'); if(!p.homepage||!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.homepage); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts
git diff --check
```

`npm pack --dry-run --ignore-scripts` was used to avoid triggering the Playwright browser install hook.