### PR TITLE
feat: OpenAPI REST endpoints for tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ async function main() {
         "[Setup] - /mcp - Streamable HTTP endpoint (modern MCP protocol)"
       );
       logger.info("[Setup] - /sse - SSE endpoint (legacy MCP protocol)");
+      logger.info("[Setup] - /openapi.json - OpenAPI 3.1 specification");
+      logger.info("[Setup] - /tools/{name} - REST tool endpoints");
     } else {
       logger.info("[Setup] Using standard input/output (stdio) transport");
     }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { TransportProvider } from "./types.js";
 import { logger } from "../utils/logger.js";
+import { registerOpenApiRoutes } from "./openapi.js";
 
 /**
  * Check if a request is an initialization request
@@ -134,6 +135,9 @@ export class HttpTransportProvider implements TransportProvider {
       await this.handleSseMessageRequest(req, res);
     });
 
+    // OpenAPI REST routes
+    registerOpenApiRoutes(this.app);
+
     // Root path response
     this.app.get("/", (_req: Request, res: Response) => {
       res.send(`
@@ -146,6 +150,8 @@ export class HttpTransportProvider implements TransportProvider {
             <ul>
               <li><code>/mcp</code> - Streamable HTTP endpoint (modern MCP protocol)</li>
               <li><code>/sse</code> - SSE endpoint (legacy MCP protocol)</li>
+              <li><code>/openapi.json</code> - OpenAPI 3.1 specification</li>
+              <li><code>/tools/{name}</code> - REST tool endpoints</li>
             </ul>
           </body>
         </html>

--- a/src/transports/openapi.ts
+++ b/src/transports/openapi.ts
@@ -1,0 +1,77 @@
+import { Request, Response } from "express";
+import { tools, toolHandlers } from "../tools/index.js";
+import { logger } from "../utils/logger.js";
+
+function buildOpenApiSpec(publicUrl: string) {
+  const paths: Record<string, any> = {};
+  const schemas: Record<string, any> = {};
+
+  for (const tool of tools) {
+    schemas[`${tool.name}_input`] = tool.inputSchema;
+    paths[`/tools/${tool.name}`] = {
+      post: {
+        operationId: tool.name,
+        summary: tool.description,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: `#/components/schemas/${tool.name}_input` },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "The fetched content as markdown (or plain text when returnText is true).",
+            content: {
+              "text/plain": {
+                schema: { type: "string" },
+              },
+            },
+          },
+          "500": {
+            description: "Tool execution error.",
+            content: {
+              "text/plain": {
+                schema: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Fetcher MCP",
+      version: "0.1.0",
+      description:
+        "Web content fetching tools. This server also speaks MCP over Streamable HTTP at POST /mcp.",
+    },
+    servers: [{ url: publicUrl }],
+    paths,
+    components: { schemas },
+  };
+}
+
+export function registerOpenApiRoutes(app: any): void {
+  app.get("/openapi.json", (req: Request, res: Response) => {
+    const proto = (req.headers["x-forwarded-proto"] as string) || req.protocol;
+    res.json(buildOpenApiSpec(`${proto}://${req.get("host")}`));
+  });
+
+  for (const tool of tools) {
+    app.post(`/tools/${tool.name}`, async (req: Request, res: Response) => {
+      try {
+        const result = await toolHandlers[tool.name](req.body);
+        const text = result?.content?.[0]?.text ?? "";
+        res.type("text/plain").send(text);
+      } catch (error: any) {
+        logger.error(`[OpenAPI] /tools/${tool.name} failed: ${error.message}`);
+        res.status(500).type("text/plain").send(error.message);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a plain OpenAPI REST interface alongside the existing MCP transport when running in HTTP mode. Any OpenAPI-aware client can discover and call tools over standard HTTP — no MCP SDK required.

- Each tool is available at `POST /tools/{name}`, returns the content as plain text
- An OpenAPI 3.1 spec is served at `GET /openapi.json` for automatic discovery
- Tool input schemas are embedded directly since OpenAPI 3.1 is JSON Schema compatible
- No new dependencies

### Endpoints

| Method | Endpoint | Description |
| --- | --- | --- |
| GET | `/openapi.json` | OpenAPI 3.1 specification |
| POST | `/tools/fetch_url` | Fetch a single URL |
| POST | `/tools/fetch_urls` | Fetch multiple URLs |
| POST | `/tools/browser_install` | Install browser binary |

### Why

Platforms like [Open WebUI](https://docs.openwebui.com/features/extensibility/plugin/tools/) can ingest an OpenAPI spec and treat every endpoint as a tool the model can call. With this change, fetcher-mcp can be used as a tool server in Open WebUI (and similar platforms) directly — without needing an MCP-to-OpenAPI bridge like mcpo as a sidecar.

## Test plan

- [x] `npm run build` passes
- [x] Start with `--transport=http` and verify `/openapi.json` returns a valid spec
- [x] `curl -X POST localhost:3000/tools/fetch_url -H 'Content-Type: application/json' -d '{"url":"https://example.com"}'` returns plain text content
- [x] Existing MCP transport at `/mcp` still works