### PR TITLE
feat: add returnText option for plain text output

### DIFF
--- a/src/services/webContentProcessor.ts
+++ b/src/services/webContentProcessor.ts
@@ -34,16 +34,20 @@ export class WebContentProcessor {
           
           // Try to retrieve page content
           try {
+            if (this.options.returnText) {
+              return await this.extractInnerText(page, url);
+            }
+
             // Directly get page information without waiting for page stability
             const { pageTitle, html } = await this.safelyGetPageInfo(page, url);
-            
+
             // If content is retrieved, process and return it
             if (html && html.trim().length > 0) {
               logger.info(`${this.logPrefix} Successfully retrieved content despite timeout, length: ${html.length}`);
-              
+
               const processedContent = await this.processContent(html, url);
               const formattedContent = `Title: ${pageTitle}\nURL: ${url}\nContent:\n\n${processedContent}`;
-              
+
               return {
                 success: true,
                 content: formattedContent,
@@ -101,7 +105,11 @@ export class WebContentProcessor {
 
       // Wait for the page to stabilize before getting content
       await this.ensurePageStability(page);
-      
+
+      if (this.options.returnText) {
+        return this.extractInnerText(page, url);
+      }
+
       // Safely retrieve page title and content
       const { pageTitle, html } = await this.safelyGetPageInfo(page, url);
 
@@ -204,6 +212,23 @@ export class WebContentProcessor {
     }
     
     return { pageTitle, html };
+  }
+
+  private async extractInnerText(page: any, url: string): Promise<FetchResult> {
+    const pageTitle = await page.title();
+    let text = await page.innerText('body');
+
+    logger.info(`${this.logPrefix} Retrieved innerText, length: ${text.length}`);
+
+    if (this.options.maxLength > 0 && text.length > this.options.maxLength) {
+      logger.info(
+        `${this.logPrefix} Content exceeds maximum length, will truncate to ${this.options.maxLength} characters`
+      );
+      text = text.substring(0, this.options.maxLength);
+    }
+
+    const formattedContent = `Title: ${pageTitle}\nURL: ${url}\nContent:\n\n${text}`;
+    return { success: true, content: formattedContent };
   }
 
   private async processContent(html: string, url: string): Promise<string> {

--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -44,6 +44,11 @@ export const fetchUrlTool = {
         description:
           "Whether to return HTML content instead of Markdown, default is false",
       },
+      returnText: {
+        type: "boolean",
+        description:
+          "Whether to return plain text (innerText) instead of Markdown. Skips content extraction and conversion entirely, returning only the visible text on the page. Default is false",
+      },
       waitForNavigation: {
         type: "boolean",
         description:
@@ -96,6 +101,7 @@ export async function fetchUrl(args: any) {
     extractContent: args?.extractContent !== false,
     maxLength: Number(args?.maxLength) || 0,
     returnHtml: args?.returnHtml === true,
+    returnText: args?.returnText === true,
     waitForNavigation: args?.waitForNavigation === true,
     navigationTimeout: Number(args?.navigationTimeout) || 10000,
     disableMedia: args?.disableMedia !== false,

--- a/src/tools/fetchUrls.ts
+++ b/src/tools/fetchUrls.ts
@@ -46,6 +46,11 @@ export const fetchUrlsTool = {
         description:
           "Whether to return HTML content instead of Markdown, default is false",
       },
+      returnText: {
+        type: "boolean",
+        description:
+          "Whether to return plain text (innerText) instead of Markdown. Skips content extraction and conversion entirely, returning only the visible text on the page. Default is false",
+      },
       waitForNavigation: {
         type: "boolean",
         description:
@@ -97,6 +102,7 @@ export async function fetchUrls(args: any) {
     extractContent: args?.extractContent !== false,
     maxLength: Number(args?.maxLength) || 0,
     returnHtml: args?.returnHtml === true,
+    returnText: args?.returnText === true,
     waitForNavigation: args?.waitForNavigation === true,
     navigationTimeout: Number(args?.navigationTimeout) || 10000,
     disableMedia: args?.disableMedia !== false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface FetchOptions {
     extractContent: boolean;
     maxLength: number;
     returnHtml: boolean;
+    returnText: boolean;
     waitForNavigation: boolean;
     navigationTimeout: number;
     disableMedia: boolean;


### PR DESCRIPTION
## Summary

Adds a `returnText` boolean option to `fetch_url` and `fetch_urls`. When true, returns `page.innerText('body')` directly — the visible text on the page with no processing.

This skips both Readability content extraction and Turndown markdown conversion, which means:
- No markup overhead (no `[links](url)`, no `**bold**`, no `# headings`)
- Fewer tokens for the model to parse
- Faster response (no JSDOM/Readability/Turndown pipeline)

### Usage

```json
{"url": "https://example.com", "returnText": true}
```

### Default (markdown)
```
This domain is for use in documentation examples without needing permission. Avoid use in operations.

[Learn more](https://iana.org/domains/example)
```

### With returnText
```
Example Domain

This domain is for use in documentation examples without needing permission. Avoid use in operations.

Learn more
```

## Test plan

- [x] `fetch_url` with `returnText: true` returns innerText only
- [x] `fetch_url` without `returnText` still returns markdown as before
- [x] `maxLength` truncation works with `returnText`
- [x] Timeout fallback path also respects `returnText`